### PR TITLE
fixing ambiguities

### DIFF
--- a/lib/types/maybe.dart
+++ b/lib/types/maybe.dart
@@ -95,19 +95,13 @@ class Maybe<T> with _$Maybe<T> {
   /// this cast sometimes. Use it wisely!
   Just<T> get asJust => this as Just<T>;
 
-  /// The [value] getter is a quick way to get the value contained in [Just], if it exists.
-  T? get value => map(
-        nothing: (_) => null,
-        just: (just) => just.value,
-      );
-
   /// The [getOrElse] method which receives a parameter to return as a
   /// fallback value, when the value is a [Nothing], or there is
   /// no value in the [Just].
   getOrElse(fallback) {
     return map(
       nothing: (_) => fallback,
-      just: (_) => value ?? fallback,
+      just: (just) => just.value ?? fallback,
     );
   }
 }

--- a/lib/types/request_status.dart
+++ b/lib/types/request_status.dart
@@ -134,14 +134,4 @@ class RequestStatus<ResultType> with _$RequestStatus<ResultType> {
   /// `strongly advised to not do that indiscriminately`. Although, it might be convenient to have
   /// this cast sometimes. Use it wisely!
   Failed get asFailed => this as Failed;
-
-  ResultType? get data => maybeWhen(
-        succeeded: (data) => data,
-        orElse: () => null,
-      );
-
-  AppError? get error => maybeWhen(
-        failed: (error) => error,
-        orElse: () => null,
-      );
 }

--- a/test/types/maybe_test.dart
+++ b/test/types/maybe_test.dart
@@ -36,31 +36,6 @@ void main() {
   );
 
   group(
-    'Test value getter',
-    () {
-      test(
-        'It should return the value when its a Just',
-        () {
-          const bool mockValue = true;
-          Maybe testJust = const Just(mockValue);
-
-          expect(testJust.value, mockValue);
-          expect(testJust.value, isA<bool>());
-        },
-      );
-
-      test(
-        'It should return null when its a Nothing',
-        () {
-          Maybe testJust = const Nothing();
-
-          expect(testJust.value, null);
-        },
-      );
-    },
-  );
-
-  group(
     'Test getOrElse method',
     () {
       test(


### PR DESCRIPTION
As I've been seeing throw projects, the T? get value for the Maybe Type and the error and data getters for the request status is producing confusion about the correct way of accessing data on those types, so I've proposed to just take those helpers off. To enforce that data should be accessed in a safe way. 