### PR TITLE
new features + tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.4.0
+
+## New
+
+- add `mapAsyncSuccess<K>` method to `Result` to chain asynchronous access to data
+- add `mapAsyncJust<K>` method to `Maybe` to chain asynchronous access to data
+- add `(Maybe<J>, Maybe<K>).maybeCombine` extension method to `(Maybe<J>, Maybe<K>)` records to neatly control access to an ordered pair of two `Maybe`s possible values
+
 ## 0.3.3
 
 ## fixes

--- a/README.md
+++ b/README.md
@@ -93,7 +93,45 @@ In this way one always needs to deal in a declarative way with both the
 success and failure possible outcomes as unfortunatelly any asynchronus
 task needs.
 
-`anti-patern alert!`: The `Result` generic Union type comes with casts convenience methods `asSuccess`, `asFailure`, but although it might be temping to just cast the result into the desired type, it is strongly advised you not to do it, once if you try to cast diferent types (`Success` as `Failure` or the other way around) it would throw an exception.
+`anti-patern alert!`: The `Result` generic Union type comes with casts convenience methods `asSuccess`, `asFailure`, but although it might be temping to just cast the result into the desired type, it is strongly advised you not to do it, once if you try to cast diferent types (`Success` as `Failure` or the other way around) it would throw an exception.<br>
+
+```dart
+Result<K> mapSuccess<K>(
+    Result<K> Function(ResultType) combiner,
+  );
+```
+
+A method used to chain access to data held by the [Result]. If `this` is [Failure] returns [Failure], if `this` is [Success], returns the result of the `combiner` method over the `data` inside [Success] <br>
+
+Example:
+
+```dart
+Result<String> asyncTaskResturningStringResult = await someFutureOfResultString();
+
+Result<double> parseResult = asyncTaskResturningStringResult.mapSuccess((String data) => methodThatTakesStringDataAndTriesToParseDouble(data));
+```
+
+```dart
+FutureOr<Result<K>> mapAsyncSuccess<K>(
+    FutureOr<Result<K>> Function(ResultType) combiner,
+);
+```
+
+A method to chain asynchronous access to data held by the [Result]. If `this` is [Failure] returns `[FutureOr<Failure>]`, if `this` is [Success], returns the result of the `combiner` method over the `data` inside [Success] <br>
+
+Example:
+
+```dart
+Result<String> asyncTaskResturningStringResult = await someFutureOfResultString();
+
+Result<double> parseResult = await asyncTaskResturningStringResult.mapAsyncSuccess((String data) => methodThatTakesStringDataAndAsynchronouslyTriesToParseDouble(data));
+```
+
+```dart
+Maybe<ResultType> get maybeData;
+```
+
+Getter that results in a [Just] if the [Result] is [Success] and [Nothing] othterwise <br>
 
 ### Maybe
 
@@ -162,6 +200,60 @@ Example:
 
 So, `Maybe` provides a safe and declarative way to always deal with the two possible states of a optional value.
 
+```dart
+factory Maybe.from(T? input);
+```
+
+Factory for helping building a [Maybe] from a nullable input. It produces a [Nothing] if the input is null, and a [Just] otherwise
+
+```dart
+Type getOrElse<Type>(Type fallback);
+```
+
+The [getOrElse] method which receives a parameter to return as a
+fallback value, when the value is a [Nothing], or there is no value in the [Just] <br>
+
+```dart
+ Maybe<K> mapJust<K>(Maybe<K> Function(T) combiner);
+```
+
+A method to chain access to data held by the [Maybe]. If `this` is [Nothing] returns [Nothing], if `this` is [Just], returns the result of the `combiner` method over the `value` inside [Just] <br>
+
+```dart
+FutureOr<Maybe<K>> mapAsyncJust<K>(FutureOr<Maybe<K>> Function(T) combiner);
+```
+
+A Method to chain async access to data held by the [Maybe]. If `this` is [Nothing] returns [Nothing], if `this` is [Just], returns the result of the `combiner` method over the `value` inside [Just]<br>
+
+```dart
+Maybe<T> maybeCombine<T>({
+    /// Used to map case where only the first value is [Just]
+    Maybe<T> Function(K)? firstJust,
+
+    /// Used to map case where only the second value is [Just]
+    Maybe<T> Function(J)? secondJust,
+
+    /// Used to map case where both values are [Just]
+    Maybe<T> Function(K, J)? bothJust,
+
+    /// Used to map case where both values are [Nothing]
+    Maybe<T> Function()? bothNothing,
+  })
+```
+
+Use it to combine two different Maybe's into a new one. Input `firstJust` to map case where only the first value is [Just], `secondJust` to map case where only the second value is [Just], `bothJust` to map case where both first and second value are [Just] and `bothNothing` to map case where both are [Nothing]<br>
+
+Example:
+
+````dart
+Maybe<Number> combined = (testString, testInt).maybeCombine<Number>(
+  bothJust: (val, number) => Just(Number(val, number, '$number$val',)),
+  firstJust: (val) => Just(Number(val, -1, '-1$val',)),
+  secondJust: (number) => Just(Number('not a trivia', number, 'NonTrivia',)),
+  bothNothing: () => Just(Number('not a trivia', -1, 'NonTrivia',)),
+       );
+```
+
 ### RequestStatus
 
 When one is dealing with ui responses to different request states, in the course of it,
@@ -170,7 +262,7 @@ So the convenience generic union type
 
 ```dart
 RequestStatus<ResultType>
-```
+````
 
 serves the purpose of modeling those states. `Idle` and `Loading`, carry no inner state, but
 
@@ -235,7 +327,14 @@ Example:
   }
 ```
 
-So, `RequestStatus` provides a safe and declarative way to always deal with all possible or desired states of a request.
+So, `RequestStatus` provides a safe and declarative way to always deal with all possible or desired states of a request. <br>
+
+```dart
+Maybe<ResultType> get maybeData;
+```
+
+Getter that results in a [Maybe] that is [Just] if the [RequestStatus] is [Succeeded] and [Nothing] otherwise
+<br>
 
 ### FormField
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -108,6 +108,10 @@ class _MyHomePageState extends State<MyHomePage> {
       numberRes = (await clientWrapper.get(
               url: '${numberField.field.getOrElse('')}?json'))
           .mapSuccess(_mapRequestToNumber);
+
+      numberRes = (await numberRes.mapAsyncSuccess((number) async =>
+              await clientWrapper.get(url: '${number.number * 2}?json')))
+          .mapSuccess(_mapRequestToNumber);
     } catch (e) {
       numberRes = Failure(
         AppUnknownError(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.1"
+    version: "1.17.2"
   connectivity_plus:
     dependency: transitive
     description:
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.2"
+    version: "0.3.3"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -179,18 +179,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.15"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
@@ -240,10 +240,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -288,10 +288,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.6.0"
   typed_data:
     dependency: transitive
     description:
@@ -308,6 +308,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   xml:
     dependency: transitive
     description:
@@ -317,5 +325,5 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=3.0.0-0 <4.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=3.0.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -20,7 +20,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.

--- a/lib/types/request_status.dart
+++ b/lib/types/request_status.dart
@@ -125,25 +125,25 @@ class RequestStatus<ResultType> with _$RequestStatus<ResultType> {
   bool get isFailed => this is Failed;
 
   /// Cast [this] into an [Idle], and throw an exception if the cast fails!
-  /// `It might be tempting to just cast the RequestSttatus into the desired type, but it's `
+  /// `It might be tempting to just cast the RequestStatus into the desired type, but it's `
   /// `strongly advised to not do that indiscriminately`. Although, it might be convenient to have
   /// this cast sometimes. Use it wisely!
   Idle get asIdle => this as Idle;
 
   /// Cast [this] into a [Loading], and throw an exception if the cast fails!
-  /// `It might be tempting to just cast the RequestSttatus into the desired type, but it's `
+  /// `It might be tempting to just cast the RequestStatus into the desired type, but it's `
   /// `strongly advised to not do that indiscriminately`. Although, it might be convenient to have
   /// this cast sometimes. Use it wisely!
   Loading get asLoading => this as Loading;
 
   /// Cast [this] into a [Succeeded], and throw an exception if the cast fails!
-  /// `It might be tempting to just cast the RequestSttatus into the desired type, but it's `
+  /// `It might be tempting to just cast the RequestStatus into the desired type, but it's `
   /// `strongly advised to not do that indiscriminately`. Although, it might be convenient to have
   /// this cast sometimes. Use it wisely!
   Succeeded get asSucceeded => this as Succeeded;
 
   /// Cast [this] into a [Failed], and throw an exception if the cast fails!
-  /// `It might be tempting to just cast the RequestSttatus into the desired type, but it's `
+  /// `It might be tempting to just cast the RequestStatus into the desired type, but it's `
   /// `strongly advised to not do that indiscriminately`. Although, it might be convenient to have
   /// this cast sometimes. Use it wisely!
   Failed get asFailed => this as Failed;

--- a/lib/types/result.dart
+++ b/lib/types/result.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:convenience_types/errors/app_error.dart';
 import 'package:convenience_types/types/maybe.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
@@ -118,8 +120,21 @@ class Result<ResultType> with _$Result<ResultType> {
     }
   }
 
-  /// Method chain access to data held by the [Result]. If `this` is [Failure] returns [Failure], if `this` is [Success], returns the result of the `combiner` method over the `data` inside [Success]
-  Result<K> mapSuccess<K>(Result<K> Function(ResultType) combiner) {
+  /// A method used to chain access to data held by the [Result]. If `this` is [Failure] returns [Failure], if `this` is [Success], returns the result of the `combiner` method over the `data` inside [Success]
+  // ignore: empty_constructor_bodies
+  Result<K> mapSuccess<K>(
+    Result<K> Function(ResultType) combiner,
+  ) {
+    return handle(
+        onSuccess: (data) => combiner(data),
+        onFailure: (error) => Failure(error));
+  }
+
+  /// A method to chain asynchronous access to data held by the [Result]. If `this` is [Failure] returns `[FutureOr<Failure>]`, if `this` is [Success], returns the result of the `combiner` method over the `data` inside [Success]
+  // ignore: empty_constructor_bodies
+  FutureOr<Result<K>> mapAsyncSuccess<K>(
+    FutureOr<Result<K>> Function(ResultType) combiner,
+  ) {
     return handle(
         onSuccess: (data) => combiner(data),
         onFailure: (error) => Failure(error));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: convenience_types
 description: A package to ensamble convenience types commonly used through flutter projects developed by Capyba.
-version: 0.3.3
+version: 0.4.0
 repository: https://github.com/CapybaHub/convenience_types_flutter
 
 environment:

--- a/test/types/maybe_test.dart
+++ b/test/types/maybe_test.dart
@@ -212,4 +212,102 @@ void main() {
       );
     },
   );
+
+  group(
+    'mapAsyncJust',
+    () {
+      test(
+        'It should return Nothing if this is Nothing',
+        () {
+          Maybe testNothing = const Nothing();
+
+          expect(
+            testNothing.mapAsyncJust((_) => const Just(true)),
+            const Nothing<bool>(),
+          );
+        },
+      );
+
+      test(
+        'It should return the result of the combiner method passing value if this is just',
+        () async {
+          Maybe<bool> testJust = const Just(true);
+          Future<Maybe<String>> combiner(bool val) async {
+            return Just(val.toString());
+          }
+
+          expect(
+            await testJust.mapAsyncJust<String>(combiner),
+            const Just('true'),
+          );
+        },
+      );
+    },
+  );
+
+  group(
+    'maybeCombine',
+    () {
+      Maybe<String> firstJust(int val) => Just(val.toString());
+      Maybe<String> secondJust(bool val) => Just(val.toString());
+      Maybe<String> bothJust(int number, bool val) =>
+          Just('$number${val.toString()}');
+      Maybe<String> bothNothing() => const Just('bothNothing');
+
+      test(
+        'It should return Nothing if both are Just but no method is passed',
+        () {
+          var testRecord = (const Just(1), const Just(true));
+          expect(
+            testRecord.maybeCombine(),
+            const Nothing(),
+          );
+        },
+      );
+
+      test(
+        'It should return the result of bothJust method if both are Just and bothJust is not null',
+        () {
+          var testRecord = (const Just(1), const Just(true));
+          expect(
+            testRecord.maybeCombine(bothJust: bothJust),
+            const Just('1true'),
+          );
+        },
+      );
+
+      test(
+        'It should return the result of firstJust method if only first value is Just and firstJust is not null',
+        () {
+          var testRecord = (const Just(1), const Nothing());
+          expect(
+            testRecord.maybeCombine(firstJust: firstJust),
+            const Just('1'),
+          );
+        },
+      );
+
+      test(
+        'It should return the result of secondJust method if only second value is Just and secondJust is not null',
+        () {
+          var testRecord = (const Nothing(), const Just(true));
+          expect(
+            testRecord.maybeCombine(secondJust: secondJust),
+            const Just('true'),
+          );
+        },
+      );
+
+      test(
+        'It should return the result of bothJust method if both values are Nothing and bothNothing is not null',
+        () {
+          var testRecord = (const Nothing(), const Nothing());
+          expect(
+            testRecord.maybeCombine(bothNothing: bothNothing),
+            const Just('bothNothing'),
+          );
+        },
+      );
+    },
+  );
 }

--- a/test/types/result_test.dart
+++ b/test/types/result_test.dart
@@ -100,4 +100,44 @@ void main() {
       );
     },
   );
+
+  group(
+    'mapAsyncSuccess',
+    () {
+      test(
+        'It should return Failure, if this is a Failure',
+        () {
+          Result<String> testResult = const Failure(AppUnknownError());
+          Future<Result<TestMapType>> combiner(String data) async {
+            return Success(TestMapType(data));
+          }
+
+          expect(
+            testResult.mapAsyncSuccess(combiner),
+            isA<Failure>(),
+          );
+        },
+      );
+
+      test(
+        'It should return the result of the combiner passing the data inside Result, if this is a Success',
+        () async {
+          Result<String> testResult = const Success('test');
+          Future<Result<TestMapType>> combiner(String data) async {
+            return Success(TestMapType(data));
+          }
+
+          (await testResult.mapAsyncSuccess(combiner)).handle(
+            onSuccess: (data) {
+              expect(data, isA<TestMapType>());
+              expect(data.data, 'test');
+            },
+            onFailure: (error) {
+              fail('unexpected failure');
+            },
+          );
+        },
+      );
+    },
+  );
 }


### PR DESCRIPTION
## New

- add `mapAsyncSuccess<K>` method to `Result` to chain asynchronous access to data
- add `mapAsyncJust<K>` method to `Maybe` to chain asynchronous access to data
- add `(Maybe<J>, Maybe<K>).maybeCombine` extension method to `(Maybe<J>, Maybe<K>)` records to neatly control access to an ordered pair of two `Maybe`s possible values

- A method to chain asynchronous access to data held by the [Result]. If `this` is [Failure] returns `[FutureOr<Failure>]`, if `this` is [Success], returns the result of the `combiner` method over the `data` inside [Success]
```dart
FutureOr<Result<K>> mapAsyncSuccess<K>(
    FutureOr<Result<K>> Function(ResultType) combiner,
  ) {
    return handle(
        onSuccess: (data) => combiner(data),
        onFailure: (error) => Failure(error));
  }
```

- A Method to chain async access to data held by the [Maybe]. If `this` is [Nothing] returns [Nothing], if `this` is [Just], returns the result of the `combiner` method over the `value` inside [Just]
```dart  
FutureOr<Maybe<K>> mapAsyncJust<K>(FutureOr<Maybe<K>> Function(T) combiner) {
    return when(
      nothing: () => Nothing<K>(),
      just: (T data) => combiner(data),
    );
  }
```

- Use it to combine two different Maybe's into a new one. Input `firstJust` to map case where only the first value is [Just], `secondJust` to map case where only the second value is [Just], `bothJust` to map case where both first and second value are [Just] and `bothNothing` to map case where both are [Nothing]
```dart
Maybe<T> maybeCombine<T>({
    /// Used to map case where only the first value is [Just]
    Maybe<T> Function(K)? firstJust,

    /// Used to map case where only the second value is [Just]
    Maybe<T> Function(J)? secondJust,

    /// Used to map case where both values are [Just]
    Maybe<T> Function(K, J)? bothJust,

    /// Used to map case where both values are [Nothing]
    Maybe<T> Function()? bothNothing,
  }) {
    return $1.when(
      nothing: () => $2.when(
        nothing: () => bothNothing != null ? bothNothing() : Nothing<T>(),
        just: (J secondData) =>
            secondJust != null ? secondJust(secondData) : Nothing<T>(),
      ),
      just: (firstData) => $2.when(
        nothing: () => firstJust != null ? firstJust(firstData) : Nothing<T>(),
        just: (J secondData) =>
            bothJust != null ? bothJust(firstData, secondData) : Nothing<T>(),
      ),
    );
  }
```