### PR TITLE
add castInto method to FormField

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+## New
+
+- add `castInto<k>` method to `FormField<T>` to help casting field types leaving names unchanged
+
 ## 0.4.0
 
 ## New

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -45,10 +45,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.17.1"
   connectivity_plus:
     dependency: transitive
     description:
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.3.3"
+    version: "0.4.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -179,18 +179,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: "6501fbd55da300384b768785b83e5ce66991266cec21af89ab9ae7f5ce1c4cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.15"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -240,10 +240,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -288,10 +288,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: eb6ac1540b26de412b3403a163d919ba86f6a973fe6cc50ae3541b80092fdcfb
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.5.1"
   typed_data:
     dependency: transitive
     description:
@@ -308,14 +308,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  web:
-    dependency: transitive
-    description:
-      name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.4-beta"
   xml:
     dependency: transitive
     description:
@@ -325,5 +317,5 @@ packages:
     source: hosted
     version: "6.2.2"
 sdks:
-  dart: ">=3.1.0-185.0.dev <4.0.0"
+  dart: ">=3.0.0 <4.0.0"
   flutter: ">=3.0.0"

--- a/lib/types/form_field.dart
+++ b/lib/types/form_field.dart
@@ -102,6 +102,7 @@ part 'form_field.freezed.dart';
 
 @freezed
 class FormField<T> with _$FormField<T> {
+  const FormField._();
   const factory FormField({
     /// Property representing the name of this [FormField] in a possible json request body
     required String name,
@@ -109,4 +110,10 @@ class FormField<T> with _$FormField<T> {
     /// Property representing the value of this [FormField] in a possible json request body
     @Default(Nothing()) Maybe<T> field,
   }) = _FormField<T>;
+
+  /// A method to help casting a FormField from a type T into a type K.
+  FormField<K> castInto<K>({
+    required Maybe<K> Function(T) combiner,
+  }) =>
+      FormField<K>(name: name, field: field.mapJust<K>(combiner));
 }

--- a/lib/types/form_field.freezed.dart
+++ b/lib/types/form_field.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'form_field.dart';
 
@@ -31,41 +31,46 @@ mixin _$FormField<T> {
 abstract class $FormFieldCopyWith<T, $Res> {
   factory $FormFieldCopyWith(
           FormField<T> value, $Res Function(FormField<T>) then) =
-      _$FormFieldCopyWithImpl<T, $Res>;
+      _$FormFieldCopyWithImpl<T, $Res, FormField<T>>;
+  @useResult
   $Res call({String name, Maybe<T> field});
 
   $MaybeCopyWith<T, $Res> get field;
 }
 
 /// @nodoc
-class _$FormFieldCopyWithImpl<T, $Res> implements $FormFieldCopyWith<T, $Res> {
+class _$FormFieldCopyWithImpl<T, $Res, $Val extends FormField<T>>
+    implements $FormFieldCopyWith<T, $Res> {
   _$FormFieldCopyWithImpl(this._value, this._then);
 
-  final FormField<T> _value;
   // ignore: unused_field
-  final $Res Function(FormField<T>) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? field = freezed,
+    Object? name = null,
+    Object? field = null,
   }) {
     return _then(_value.copyWith(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      field: field == freezed
+      field: null == field
           ? _value.field
           : field // ignore: cast_nullable_to_non_nullable
               as Maybe<T>,
-    ));
+    ) as $Val);
   }
 
   @override
+  @pragma('vm:prefer-inline')
   $MaybeCopyWith<T, $Res> get field {
     return $MaybeCopyWith<T, $Res>(_value.field, (value) {
-      return _then(_value.copyWith(field: value));
+      return _then(_value.copyWith(field: value) as $Val);
     });
   }
 }
@@ -77,6 +82,7 @@ abstract class _$$_FormFieldCopyWith<T, $Res>
           _$_FormField<T> value, $Res Function(_$_FormField<T>) then) =
       __$$_FormFieldCopyWithImpl<T, $Res>;
   @override
+  @useResult
   $Res call({String name, Maybe<T> field});
 
   @override
@@ -85,26 +91,24 @@ abstract class _$$_FormFieldCopyWith<T, $Res>
 
 /// @nodoc
 class __$$_FormFieldCopyWithImpl<T, $Res>
-    extends _$FormFieldCopyWithImpl<T, $Res>
+    extends _$FormFieldCopyWithImpl<T, $Res, _$_FormField<T>>
     implements _$$_FormFieldCopyWith<T, $Res> {
   __$$_FormFieldCopyWithImpl(
       _$_FormField<T> _value, $Res Function(_$_FormField<T>) _then)
-      : super(_value, (v) => _then(v as _$_FormField<T>));
+      : super(_value, _then);
 
-  @override
-  _$_FormField<T> get _value => super._value as _$_FormField<T>;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? name = freezed,
-    Object? field = freezed,
+    Object? name = null,
+    Object? field = null,
   }) {
     return _then(_$_FormField<T>(
-      name: name == freezed
+      name: null == name
           ? _value.name
           : name // ignore: cast_nullable_to_non_nullable
               as String,
-      field: field == freezed
+      field: null == field
           ? _value.field
           : field // ignore: cast_nullable_to_non_nullable
               as Maybe<T>,
@@ -114,8 +118,9 @@ class __$$_FormFieldCopyWithImpl<T, $Res>
 
 /// @nodoc
 
-class _$_FormField<T> implements _FormField<T> {
-  const _$_FormField({required this.name, this.field = const Nothing()});
+class _$_FormField<T> extends _FormField<T> {
+  const _$_FormField({required this.name, this.field = const Nothing()})
+      : super._();
 
   /// Property representing the name of this [FormField] in a possible json request body
   @override
@@ -136,34 +141,33 @@ class _$_FormField<T> implements _FormField<T> {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$_FormField<T> &&
-            const DeepCollectionEquality().equals(other.name, name) &&
-            const DeepCollectionEquality().equals(other.field, field));
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.field, field) || other.field == field));
   }
 
   @override
-  int get hashCode => Object.hash(
-      runtimeType,
-      const DeepCollectionEquality().hash(name),
-      const DeepCollectionEquality().hash(field));
+  int get hashCode => Object.hash(runtimeType, name, field);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$_FormFieldCopyWith<T, _$_FormField<T>> get copyWith =>
       __$$_FormFieldCopyWithImpl<T, _$_FormField<T>>(this, _$identity);
 }
 
-abstract class _FormField<T> implements FormField<T> {
+abstract class _FormField<T> extends FormField<T> {
   const factory _FormField({required final String name, final Maybe<T> field}) =
       _$_FormField<T>;
+  const _FormField._() : super._();
 
   @override
 
   /// Property representing the name of this [FormField] in a possible json request body
-  String get name => throw _privateConstructorUsedError;
+  String get name;
   @override
 
   /// Property representing the value of this [FormField] in a possible json request body
-  Maybe<T> get field => throw _privateConstructorUsedError;
+  Maybe<T> get field;
   @override
   @JsonKey(ignore: true)
   _$$_FormFieldCopyWith<T, _$_FormField<T>> get copyWith =>

--- a/lib/types/maybe.freezed.dart
+++ b/lib/types/maybe.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'maybe.dart';
 
@@ -24,8 +24,8 @@ mixin _$Maybe<T> {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? nothing,
-    TResult Function(T value)? just,
+    TResult? Function()? nothing,
+    TResult? Function(T value)? just,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -43,8 +43,8 @@ mixin _$Maybe<T> {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(Nothing<T> value)? nothing,
-    TResult Function(Just<T> value)? just,
+    TResult? Function(Nothing<T> value)? nothing,
+    TResult? Function(Just<T> value)? just,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -59,16 +59,18 @@ mixin _$Maybe<T> {
 /// @nodoc
 abstract class $MaybeCopyWith<T, $Res> {
   factory $MaybeCopyWith(Maybe<T> value, $Res Function(Maybe<T>) then) =
-      _$MaybeCopyWithImpl<T, $Res>;
+      _$MaybeCopyWithImpl<T, $Res, Maybe<T>>;
 }
 
 /// @nodoc
-class _$MaybeCopyWithImpl<T, $Res> implements $MaybeCopyWith<T, $Res> {
+class _$MaybeCopyWithImpl<T, $Res, $Val extends Maybe<T>>
+    implements $MaybeCopyWith<T, $Res> {
   _$MaybeCopyWithImpl(this._value, this._then);
 
-  final Maybe<T> _value;
   // ignore: unused_field
-  final $Res Function(Maybe<T>) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 }
 
 /// @nodoc
@@ -79,14 +81,12 @@ abstract class _$$NothingCopyWith<T, $Res> {
 }
 
 /// @nodoc
-class __$$NothingCopyWithImpl<T, $Res> extends _$MaybeCopyWithImpl<T, $Res>
+class __$$NothingCopyWithImpl<T, $Res>
+    extends _$MaybeCopyWithImpl<T, $Res, _$Nothing<T>>
     implements _$$NothingCopyWith<T, $Res> {
   __$$NothingCopyWithImpl(
       _$Nothing<T> _value, $Res Function(_$Nothing<T>) _then)
-      : super(_value, (v) => _then(v as _$Nothing<T>));
-
-  @override
-  _$Nothing<T> get _value => super._value as _$Nothing<T>;
+      : super(_value, _then);
 }
 
 /// @nodoc
@@ -120,8 +120,8 @@ class _$Nothing<T> extends Nothing<T> {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? nothing,
-    TResult Function(T value)? just,
+    TResult? Function()? nothing,
+    TResult? Function(T value)? just,
   }) {
     return nothing?.call();
   }
@@ -151,8 +151,8 @@ class _$Nothing<T> extends Nothing<T> {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(Nothing<T> value)? nothing,
-    TResult Function(Just<T> value)? just,
+    TResult? Function(Nothing<T> value)? nothing,
+    TResult? Function(Just<T> value)? just,
   }) {
     return nothing?.call(this);
   }
@@ -180,24 +180,24 @@ abstract class Nothing<T> extends Maybe<T> {
 abstract class _$$JustCopyWith<T, $Res> {
   factory _$$JustCopyWith(_$Just<T> value, $Res Function(_$Just<T>) then) =
       __$$JustCopyWithImpl<T, $Res>;
+  @useResult
   $Res call({T value});
 }
 
 /// @nodoc
-class __$$JustCopyWithImpl<T, $Res> extends _$MaybeCopyWithImpl<T, $Res>
+class __$$JustCopyWithImpl<T, $Res>
+    extends _$MaybeCopyWithImpl<T, $Res, _$Just<T>>
     implements _$$JustCopyWith<T, $Res> {
   __$$JustCopyWithImpl(_$Just<T> _value, $Res Function(_$Just<T>) _then)
-      : super(_value, (v) => _then(v as _$Just<T>));
+      : super(_value, _then);
 
-  @override
-  _$Just<T> get _value => super._value as _$Just<T>;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? value = freezed,
   }) {
     return _then(_$Just<T>(
-      value == freezed
+      freezed == value
           ? _value.value
           : value // ignore: cast_nullable_to_non_nullable
               as T,
@@ -232,6 +232,7 @@ class _$Just<T> extends Just<T> {
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$JustCopyWith<T, _$Just<T>> get copyWith =>
       __$$JustCopyWithImpl<T, _$Just<T>>(this, _$identity);
 
@@ -247,8 +248,8 @@ class _$Just<T> extends Just<T> {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? nothing,
-    TResult Function(T value)? just,
+    TResult? Function()? nothing,
+    TResult? Function(T value)? just,
   }) {
     return just?.call(value);
   }
@@ -278,8 +279,8 @@ class _$Just<T> extends Just<T> {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(Nothing<T> value)? nothing,
-    TResult Function(Just<T> value)? just,
+    TResult? Function(Nothing<T> value)? nothing,
+    TResult? Function(Just<T> value)? just,
   }) {
     return just?.call(this);
   }
@@ -302,7 +303,7 @@ abstract class Just<T> extends Maybe<T> {
   const factory Just(final T value) = _$Just<T>;
   const Just._() : super._();
 
-  T get value => throw _privateConstructorUsedError;
+  T get value;
   @JsonKey(ignore: true)
   _$$JustCopyWith<T, _$Just<T>> get copyWith =>
       throw _privateConstructorUsedError;

--- a/lib/types/request_status.freezed.dart
+++ b/lib/types/request_status.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'request_status.dart';
 
@@ -26,10 +26,10 @@ mixin _$RequestStatus<ResultType> {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? idle,
-    TResult Function()? loading,
-    TResult Function(ResultType data)? succeeded,
-    TResult Function(AppError error)? failed,
+    TResult? Function()? idle,
+    TResult? Function()? loading,
+    TResult? Function(ResultType data)? succeeded,
+    TResult? Function(AppError error)? failed,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -51,10 +51,10 @@ mixin _$RequestStatus<ResultType> {
       throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(Idle<ResultType> value)? idle,
-    TResult Function(Loading<ResultType> value)? loading,
-    TResult Function(Succeeded<ResultType> value)? succeeded,
-    TResult Function(Failed<ResultType> value)? failed,
+    TResult? Function(Idle<ResultType> value)? idle,
+    TResult? Function(Loading<ResultType> value)? loading,
+    TResult? Function(Succeeded<ResultType> value)? succeeded,
+    TResult? Function(Failed<ResultType> value)? failed,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -72,17 +72,19 @@ mixin _$RequestStatus<ResultType> {
 abstract class $RequestStatusCopyWith<ResultType, $Res> {
   factory $RequestStatusCopyWith(RequestStatus<ResultType> value,
           $Res Function(RequestStatus<ResultType>) then) =
-      _$RequestStatusCopyWithImpl<ResultType, $Res>;
+      _$RequestStatusCopyWithImpl<ResultType, $Res, RequestStatus<ResultType>>;
 }
 
 /// @nodoc
-class _$RequestStatusCopyWithImpl<ResultType, $Res>
+class _$RequestStatusCopyWithImpl<ResultType, $Res,
+        $Val extends RequestStatus<ResultType>>
     implements $RequestStatusCopyWith<ResultType, $Res> {
   _$RequestStatusCopyWithImpl(this._value, this._then);
 
-  final RequestStatus<ResultType> _value;
   // ignore: unused_field
-  final $Res Function(RequestStatus<ResultType>) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 }
 
 /// @nodoc
@@ -94,14 +96,11 @@ abstract class _$$IdleCopyWith<ResultType, $Res> {
 
 /// @nodoc
 class __$$IdleCopyWithImpl<ResultType, $Res>
-    extends _$RequestStatusCopyWithImpl<ResultType, $Res>
+    extends _$RequestStatusCopyWithImpl<ResultType, $Res, _$Idle<ResultType>>
     implements _$$IdleCopyWith<ResultType, $Res> {
   __$$IdleCopyWithImpl(
       _$Idle<ResultType> _value, $Res Function(_$Idle<ResultType>) _then)
-      : super(_value, (v) => _then(v as _$Idle<ResultType>));
-
-  @override
-  _$Idle<ResultType> get _value => super._value as _$Idle<ResultType>;
+      : super(_value, _then);
 }
 
 /// @nodoc
@@ -137,10 +136,10 @@ class _$Idle<ResultType> extends Idle<ResultType> {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? idle,
-    TResult Function()? loading,
-    TResult Function(ResultType data)? succeeded,
-    TResult Function(AppError error)? failed,
+    TResult? Function()? idle,
+    TResult? Function()? loading,
+    TResult? Function(ResultType data)? succeeded,
+    TResult? Function(AppError error)? failed,
   }) {
     return idle?.call();
   }
@@ -174,10 +173,10 @@ class _$Idle<ResultType> extends Idle<ResultType> {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(Idle<ResultType> value)? idle,
-    TResult Function(Loading<ResultType> value)? loading,
-    TResult Function(Succeeded<ResultType> value)? succeeded,
-    TResult Function(Failed<ResultType> value)? failed,
+    TResult? Function(Idle<ResultType> value)? idle,
+    TResult? Function(Loading<ResultType> value)? loading,
+    TResult? Function(Succeeded<ResultType> value)? succeeded,
+    TResult? Function(Failed<ResultType> value)? failed,
   }) {
     return idle?.call(this);
   }
@@ -212,14 +211,11 @@ abstract class _$$LoadingCopyWith<ResultType, $Res> {
 
 /// @nodoc
 class __$$LoadingCopyWithImpl<ResultType, $Res>
-    extends _$RequestStatusCopyWithImpl<ResultType, $Res>
+    extends _$RequestStatusCopyWithImpl<ResultType, $Res, _$Loading<ResultType>>
     implements _$$LoadingCopyWith<ResultType, $Res> {
   __$$LoadingCopyWithImpl(
       _$Loading<ResultType> _value, $Res Function(_$Loading<ResultType>) _then)
-      : super(_value, (v) => _then(v as _$Loading<ResultType>));
-
-  @override
-  _$Loading<ResultType> get _value => super._value as _$Loading<ResultType>;
+      : super(_value, _then);
 }
 
 /// @nodoc
@@ -255,10 +251,10 @@ class _$Loading<ResultType> extends Loading<ResultType> {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? idle,
-    TResult Function()? loading,
-    TResult Function(ResultType data)? succeeded,
-    TResult Function(AppError error)? failed,
+    TResult? Function()? idle,
+    TResult? Function()? loading,
+    TResult? Function(ResultType data)? succeeded,
+    TResult? Function(AppError error)? failed,
   }) {
     return loading?.call();
   }
@@ -292,10 +288,10 @@ class _$Loading<ResultType> extends Loading<ResultType> {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(Idle<ResultType> value)? idle,
-    TResult Function(Loading<ResultType> value)? loading,
-    TResult Function(Succeeded<ResultType> value)? succeeded,
-    TResult Function(Failed<ResultType> value)? failed,
+    TResult? Function(Idle<ResultType> value)? idle,
+    TResult? Function(Loading<ResultType> value)? loading,
+    TResult? Function(Succeeded<ResultType> value)? succeeded,
+    TResult? Function(Failed<ResultType> value)? failed,
   }) {
     return loading?.call(this);
   }
@@ -326,26 +322,26 @@ abstract class _$$SucceededCopyWith<ResultType, $Res> {
   factory _$$SucceededCopyWith(_$Succeeded<ResultType> value,
           $Res Function(_$Succeeded<ResultType>) then) =
       __$$SucceededCopyWithImpl<ResultType, $Res>;
+  @useResult
   $Res call({ResultType data});
 }
 
 /// @nodoc
 class __$$SucceededCopyWithImpl<ResultType, $Res>
-    extends _$RequestStatusCopyWithImpl<ResultType, $Res>
+    extends _$RequestStatusCopyWithImpl<ResultType, $Res,
+        _$Succeeded<ResultType>>
     implements _$$SucceededCopyWith<ResultType, $Res> {
   __$$SucceededCopyWithImpl(_$Succeeded<ResultType> _value,
       $Res Function(_$Succeeded<ResultType>) _then)
-      : super(_value, (v) => _then(v as _$Succeeded<ResultType>));
+      : super(_value, _then);
 
-  @override
-  _$Succeeded<ResultType> get _value => super._value as _$Succeeded<ResultType>;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? data = freezed,
   }) {
     return _then(_$Succeeded<ResultType>(
-      data == freezed
+      freezed == data
           ? _value.data
           : data // ignore: cast_nullable_to_non_nullable
               as ResultType,
@@ -380,6 +376,7 @@ class _$Succeeded<ResultType> extends Succeeded<ResultType> {
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$SucceededCopyWith<ResultType, _$Succeeded<ResultType>> get copyWith =>
       __$$SucceededCopyWithImpl<ResultType, _$Succeeded<ResultType>>(
           this, _$identity);
@@ -398,10 +395,10 @@ class _$Succeeded<ResultType> extends Succeeded<ResultType> {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? idle,
-    TResult Function()? loading,
-    TResult Function(ResultType data)? succeeded,
-    TResult Function(AppError error)? failed,
+    TResult? Function()? idle,
+    TResult? Function()? loading,
+    TResult? Function(ResultType data)? succeeded,
+    TResult? Function(AppError error)? failed,
   }) {
     return succeeded?.call(data);
   }
@@ -435,10 +432,10 @@ class _$Succeeded<ResultType> extends Succeeded<ResultType> {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(Idle<ResultType> value)? idle,
-    TResult Function(Loading<ResultType> value)? loading,
-    TResult Function(Succeeded<ResultType> value)? succeeded,
-    TResult Function(Failed<ResultType> value)? failed,
+    TResult? Function(Idle<ResultType> value)? idle,
+    TResult? Function(Loading<ResultType> value)? loading,
+    TResult? Function(Succeeded<ResultType> value)? succeeded,
+    TResult? Function(Failed<ResultType> value)? failed,
   }) {
     return succeeded?.call(this);
   }
@@ -463,7 +460,7 @@ abstract class Succeeded<ResultType> extends RequestStatus<ResultType> {
   const factory Succeeded(final ResultType data) = _$Succeeded<ResultType>;
   const Succeeded._() : super._();
 
-  ResultType get data => throw _privateConstructorUsedError;
+  ResultType get data;
   @JsonKey(ignore: true)
   _$$SucceededCopyWith<ResultType, _$Succeeded<ResultType>> get copyWith =>
       throw _privateConstructorUsedError;
@@ -474,26 +471,25 @@ abstract class _$$FailedCopyWith<ResultType, $Res> {
   factory _$$FailedCopyWith(_$Failed<ResultType> value,
           $Res Function(_$Failed<ResultType>) then) =
       __$$FailedCopyWithImpl<ResultType, $Res>;
+  @useResult
   $Res call({AppError error});
 }
 
 /// @nodoc
 class __$$FailedCopyWithImpl<ResultType, $Res>
-    extends _$RequestStatusCopyWithImpl<ResultType, $Res>
+    extends _$RequestStatusCopyWithImpl<ResultType, $Res, _$Failed<ResultType>>
     implements _$$FailedCopyWith<ResultType, $Res> {
   __$$FailedCopyWithImpl(
       _$Failed<ResultType> _value, $Res Function(_$Failed<ResultType>) _then)
-      : super(_value, (v) => _then(v as _$Failed<ResultType>));
+      : super(_value, _then);
 
-  @override
-  _$Failed<ResultType> get _value => super._value as _$Failed<ResultType>;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? error = freezed,
+    Object? error = null,
   }) {
     return _then(_$Failed<ResultType>(
-      error == freezed
+      null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
               as AppError,
@@ -519,15 +515,15 @@ class _$Failed<ResultType> extends Failed<ResultType> {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$Failed<ResultType> &&
-            const DeepCollectionEquality().equals(other.error, error));
+            (identical(other.error, error) || other.error == error));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(error));
+  int get hashCode => Object.hash(runtimeType, error);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$FailedCopyWith<ResultType, _$Failed<ResultType>> get copyWith =>
       __$$FailedCopyWithImpl<ResultType, _$Failed<ResultType>>(
           this, _$identity);
@@ -546,10 +542,10 @@ class _$Failed<ResultType> extends Failed<ResultType> {
   @override
   @optionalTypeArgs
   TResult? whenOrNull<TResult extends Object?>({
-    TResult Function()? idle,
-    TResult Function()? loading,
-    TResult Function(ResultType data)? succeeded,
-    TResult Function(AppError error)? failed,
+    TResult? Function()? idle,
+    TResult? Function()? loading,
+    TResult? Function(ResultType data)? succeeded,
+    TResult? Function(AppError error)? failed,
   }) {
     return failed?.call(error);
   }
@@ -583,10 +579,10 @@ class _$Failed<ResultType> extends Failed<ResultType> {
   @override
   @optionalTypeArgs
   TResult? mapOrNull<TResult extends Object?>({
-    TResult Function(Idle<ResultType> value)? idle,
-    TResult Function(Loading<ResultType> value)? loading,
-    TResult Function(Succeeded<ResultType> value)? succeeded,
-    TResult Function(Failed<ResultType> value)? failed,
+    TResult? Function(Idle<ResultType> value)? idle,
+    TResult? Function(Loading<ResultType> value)? loading,
+    TResult? Function(Succeeded<ResultType> value)? succeeded,
+    TResult? Function(Failed<ResultType> value)? failed,
   }) {
     return failed?.call(this);
   }
@@ -611,7 +607,7 @@ abstract class Failed<ResultType> extends RequestStatus<ResultType> {
   const factory Failed(final AppError error) = _$Failed<ResultType>;
   const Failed._() : super._();
 
-  AppError get error => throw _privateConstructorUsedError;
+  AppError get error;
   @JsonKey(ignore: true)
   _$$FailedCopyWith<ResultType, _$Failed<ResultType>> get copyWith =>
       throw _privateConstructorUsedError;

--- a/lib/types/result.freezed.dart
+++ b/lib/types/result.freezed.dart
@@ -1,7 +1,7 @@
 // coverage:ignore-file
 // GENERATED CODE - DO NOT MODIFY BY HAND
 // ignore_for_file: type=lint
-// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
 
 part of 'result.dart';
 
@@ -21,17 +21,18 @@ mixin _$Result<ResultType> {}
 abstract class $ResultCopyWith<ResultType, $Res> {
   factory $ResultCopyWith(
           Result<ResultType> value, $Res Function(Result<ResultType>) then) =
-      _$ResultCopyWithImpl<ResultType, $Res>;
+      _$ResultCopyWithImpl<ResultType, $Res, Result<ResultType>>;
 }
 
 /// @nodoc
-class _$ResultCopyWithImpl<ResultType, $Res>
+class _$ResultCopyWithImpl<ResultType, $Res, $Val extends Result<ResultType>>
     implements $ResultCopyWith<ResultType, $Res> {
   _$ResultCopyWithImpl(this._value, this._then);
 
-  final Result<ResultType> _value;
   // ignore: unused_field
-  final $Res Function(Result<ResultType>) _then;
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
 }
 
 /// @nodoc
@@ -39,26 +40,25 @@ abstract class _$$SuccessCopyWith<ResultType, $Res> {
   factory _$$SuccessCopyWith(_$Success<ResultType> value,
           $Res Function(_$Success<ResultType>) then) =
       __$$SuccessCopyWithImpl<ResultType, $Res>;
+  @useResult
   $Res call({ResultType data});
 }
 
 /// @nodoc
 class __$$SuccessCopyWithImpl<ResultType, $Res>
-    extends _$ResultCopyWithImpl<ResultType, $Res>
+    extends _$ResultCopyWithImpl<ResultType, $Res, _$Success<ResultType>>
     implements _$$SuccessCopyWith<ResultType, $Res> {
   __$$SuccessCopyWithImpl(
       _$Success<ResultType> _value, $Res Function(_$Success<ResultType>) _then)
-      : super(_value, (v) => _then(v as _$Success<ResultType>));
+      : super(_value, _then);
 
-  @override
-  _$Success<ResultType> get _value => super._value as _$Success<ResultType>;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
     Object? data = freezed,
   }) {
     return _then(_$Success<ResultType>(
-      data == freezed
+      freezed == data
           ? _value.data
           : data // ignore: cast_nullable_to_non_nullable
               as ResultType,
@@ -93,6 +93,7 @@ class _$Success<ResultType> extends Success<ResultType> {
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$SuccessCopyWith<ResultType, _$Success<ResultType>> get copyWith =>
       __$$SuccessCopyWithImpl<ResultType, _$Success<ResultType>>(
           this, _$identity);
@@ -102,7 +103,7 @@ abstract class Success<ResultType> extends Result<ResultType> {
   const factory Success(final ResultType data) = _$Success<ResultType>;
   const Success._() : super._();
 
-  ResultType get data => throw _privateConstructorUsedError;
+  ResultType get data;
   @JsonKey(ignore: true)
   _$$SuccessCopyWith<ResultType, _$Success<ResultType>> get copyWith =>
       throw _privateConstructorUsedError;
@@ -113,26 +114,25 @@ abstract class _$$FailureCopyWith<ResultType, $Res> {
   factory _$$FailureCopyWith(_$Failure<ResultType> value,
           $Res Function(_$Failure<ResultType>) then) =
       __$$FailureCopyWithImpl<ResultType, $Res>;
+  @useResult
   $Res call({AppError error});
 }
 
 /// @nodoc
 class __$$FailureCopyWithImpl<ResultType, $Res>
-    extends _$ResultCopyWithImpl<ResultType, $Res>
+    extends _$ResultCopyWithImpl<ResultType, $Res, _$Failure<ResultType>>
     implements _$$FailureCopyWith<ResultType, $Res> {
   __$$FailureCopyWithImpl(
       _$Failure<ResultType> _value, $Res Function(_$Failure<ResultType>) _then)
-      : super(_value, (v) => _then(v as _$Failure<ResultType>));
+      : super(_value, _then);
 
-  @override
-  _$Failure<ResultType> get _value => super._value as _$Failure<ResultType>;
-
+  @pragma('vm:prefer-inline')
   @override
   $Res call({
-    Object? error = freezed,
+    Object? error = null,
   }) {
     return _then(_$Failure<ResultType>(
-      error == freezed
+      null == error
           ? _value.error
           : error // ignore: cast_nullable_to_non_nullable
               as AppError,
@@ -158,15 +158,15 @@ class _$Failure<ResultType> extends Failure<ResultType> {
     return identical(this, other) ||
         (other.runtimeType == runtimeType &&
             other is _$Failure<ResultType> &&
-            const DeepCollectionEquality().equals(other.error, error));
+            (identical(other.error, error) || other.error == error));
   }
 
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, const DeepCollectionEquality().hash(error));
+  int get hashCode => Object.hash(runtimeType, error);
 
   @JsonKey(ignore: true)
   @override
+  @pragma('vm:prefer-inline')
   _$$FailureCopyWith<ResultType, _$Failure<ResultType>> get copyWith =>
       __$$FailureCopyWithImpl<ResultType, _$Failure<ResultType>>(
           this, _$identity);
@@ -176,7 +176,7 @@ abstract class Failure<ResultType> extends Result<ResultType> {
   const factory Failure(final AppError error) = _$Failure<ResultType>;
   const Failure._() : super._();
 
-  AppError get error => throw _privateConstructorUsedError;
+  AppError get error;
   @JsonKey(ignore: true)
   _$$FailureCopyWith<ResultType, _$Failure<ResultType>> get copyWith =>
       throw _privateConstructorUsedError;

--- a/test/types/form_field_test.dart
+++ b/test/types/form_field_test.dart
@@ -1,0 +1,23 @@
+import 'package:convenience_types/types/form_field.dart';
+import 'package:convenience_types/types/maybe.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group(
+    'castInto',
+    () {
+      test(
+        'It should return a new FormField with the new Type, the resulting field should be the return of combiner, the name should be the same',
+        () {
+          FormField<String> testFormField =
+              const FormField(name: 'test', field: Just('1.0'));
+          FormField<double> castedField = testFormField.castInto(
+              combiner: (input) => Maybe.from(double.tryParse(input)));
+
+          expect(castedField.name, testFormField.name);
+          expect(castedField.field, const Just(1.0));
+        },
+      );
+    },
+  );
+}


### PR DESCRIPTION
## New

- add `castInto<k>` method to `FormField<T>` to help casting field types leaving names unchanged