### PR TITLE
documentation improvements + test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.9.1
+
+- add 100% test coverage for all types and errors API surface
+- fix `prefer_function_declarations_over_variables` lint rules in example app
+- refactor tests to support stricter `Nothing<Never>` type checks natively
+- add `mocktail` as a dev dependency to test HTTP responses and DioException fallback handling
+
 ## 0.9.0
 
 - add NoParams type

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Across our projects we have adopted types that keep code safer, less error-prone
       <li><a href="#usecase">UseCase</a></li>
     </ol>
   </li>
-  <li><a href="#ppError">AppError</a></li>
+  <li><a href="#apperror">AppError</a></li>
   <li><a href="#valueErrors">ValueErrors</a></li>
   <li><a href="#util">Util</a>
     <ol>
@@ -111,6 +111,12 @@ Maybe.from(null);   // Nothing()
 Maybe.from("hi");   // Just("hi")
 ```
 
+**From Result:**
+
+```dart
+Maybe.fromResult(someResult);  // Just(data) or Nothing()
+```
+
 **Chaining:** `mapJust` / `mapAsyncJust` transform the value when `Just` and preserve `Nothing`. `mapNothing` / `mapAsyncNothing` run a callback when `Nothing` and return this `Maybe` unchanged when `Just`. Use `getOrElse(fallback)` to get the value or a fallback when `Nothing` (or when the inner value is null).
 
 **Combining two Maybes:** On a record `(Maybe<K>, Maybe<J>)`, call `maybeCombine` (or `maybeAsyncCombine`) with optional callbacks for `firstJust`, `secondJust`, `bothJust`, and `bothNothing`; omitted callbacks yield `Nothing`.
@@ -142,82 +148,41 @@ The package also provides an **identity function** `identity<T>(T value) => valu
 
 ### RequestStatus
 
-When one is dealing with ui responses to different request states, in the course of it,
-usually there are four states of interest: `Idle`, `Loading`, `Succeeded` or `Failed`.<br>
-So the convenience generic union type
+A type-safe way to model the lifecycle of an asynchronous request in the UI. `RequestStatus<ResultType>` is a union type with four states:
+
+- **Idle** — the request has not been fired yet
+- **Loading** — the request is in flight
+- **Succeeded&lt;ResultType&gt;** — carries a `data` field of type `ResultType`
+- **Failed** — carries an `AppError` in its `error` field
+
+Use `RequestStatus.fromResult(result)` to build a status directly from a `Result`.
+
+**Handle all states with pattern matching (`switch` expression):**
 
 ```dart
-RequestStatus<ResultType>
-````
-
-serves the purpose of modeling those states. `Idle` and `Loading`, carry no inner state, but
-
-```dart
-Succeeded<ResultType>().data = ResultType data;
+Widget build(BuildContext context) {
+  return switch (requestStatus) {
+    Idle() => const SizedBox.shrink(),
+    Loading() => const CircularProgressIndicator(),
+    Succeeded(:final data) => Text(data.toString()),
+    Failed(:final error) => Text(error.msg),
+  };
+}
 ```
 
-contains a field `data` of type `ResultType`. And the
+**Handle only some states using a wildcard `_`:**
 
 ```dart
-Failed().error = AppError error;
+Widget build(BuildContext context) {
+  return switch (requestStatus) {
+    Loading() => const CircularProgressIndicator(),
+    Succeeded(:final data) => Text(data.toString()),
+    _ => const SizedBox.shrink(), // catches Idle and Failed
+  };
+}
 ```
 
-contains a field `error` of type `AppError`. Where `AppError` is the convenience type
-that models errors in the app.<br>
-To deal with the request states one should use one of the unions methods.<br>
-The `.map` forces you to deal with all the four states explicitly, passing callbacks for
-each state with non-destructured states.
-Example:
-
-```dart
-  Widget build(context) {
-    final someRequestStatus = someStateManagement.desiredRequestStatus;
-    return someRequestStatus.map(
-              idle: (idle) => "widget for idle state",
-              loading: (loading) => "widget for loading state",
-              succeeded: (succeeded) => "widget for succeeded state using possibly data within succeeded.data",
-              failed: (failed) => "widget for failed state using possibly AppError within failed.error",
-          );
-  }
-```
-
-The `.when` forces you to deal with all the four states explicitly, passing callbacks for
-each state with destructured states.
-Example:
-
-```dart
-  Widget build(context) {
-    final someRequestStatus = someStateManagement.desiredRequestStatus;
-    return someRequestStatus.when(
-              idle: () => "widget for idle state",
-              loading: () => "widget for loading state",
-              succeeded: (data) => "widget for succeeded state using possibly data within data",
-              failed: (error) => "widget for failed state using possibly AppError within error",
-          );
-  }
-```
-
-You can also use `.maybeMap` and `.maybeWhen`, passing only the cases you care about and an `orElse` callback for the rest.
-Example:
-
-```dart
-  Widget build(context) {
-    final someRequestStatus = someStateManagement.desiredRequestStatus;
-    return someRequestStatus.maybeWhen(
-              orElse: () => "default widget to be displayed when the current state is not specified in other callbacks",
-              loading: () => "widget for loading state",
-              succeeded: (data) => "widget for succeeded state using possibly data within succeeded.data",
-          );
-  }
-```
-
-So, `RequestStatus` provides a safe and declarative way to always deal with all possible or desired states of a request. <br>
-
-```dart
-Maybe<ResultType> get maybeData;
-```
-
-Getter that results in a [Maybe] that is [Just] if the [RequestStatus] is [Succeeded] and [Nothing] otherwise.<br>
+**Extras:** `maybeData` returns `Just(data)` when `Succeeded`, `Nothing` otherwise. Bool convenience getters: `isIdle`, `isLoading`, `isSucceeded`, `isFailed`. Unsafe casting helpers `asIdle`, `asLoading`, `asSucceeded`, `asFailed` throw if the variant is wrong — prefer pattern matching instead.
 
 ### FormField
 
@@ -235,7 +200,7 @@ FormField<Type>
 
 is a convenience type that models, as the name already points,
 a field in a Form, and uses the convention of not passing not filled fields to the resulting `Map`.
-Here we are already passing the [name] of the field in its possible `Map`
+But here we are already passing the [name] of the field in its possible `Map`
 (json) position, and the actual [field] data is a `Maybe<Type>`.
 <br>
 `FormField`s are usually used in a `Form` defined class, and with the usage of
@@ -249,7 +214,7 @@ Example (using `freezed` to create the `Form` class):
 
 ```dart
  @freezed
- class FormExampleWithFreezed with _$FormExampleWithFreezed, FormUtils {
+ abstract class FormExampleWithFreezed with _$FormExampleWithFreezed, FormUtils {
    const FormExampleWithFreezed._();
    const factory FormExampleWithFreezed({
      @Default(FormField(name: 'firstFieldJsonName'))
@@ -341,13 +306,25 @@ Base type for a use case: a single async operation that takes **Params** and ret
 
 ## AppError
 
-Abstract class to model errors in the application. As a preset of foreseen
-specific errors there are several implementations of this type. Namely:
-[HttpError] models errors related to http requests
-[CacheError] models cache errors
-[DeviceInfoError] models device's information gathering related errors
-[FormError] models form related errors
-[StorageError] models storage operations related errors
+Abstract base class for all application errors.
+
+Provides a common interface for typed, structured error handling. All errors
+carry a `slug` (machine-readable identifier), a `msg` (human-readable
+message), and an optional `stackTrace`.
+
+Preset concrete subclasses cover the most common error domains:
+- `HttpError` — HTTP request failures (network, status codes, etc.)
+- `CacheError` — Local cache read/write failures
+- `DeviceInfoError` — Device information retrieval failures
+- `FormError` — Form validation and submission failures
+- `StorageError` — Device storage access failures
+
+General-purpose subclasses are also provided:
+- `AppUnknownError` — Unexpected or unclassified errors
+- `ParseError` — Data parsing or deserialization failures
+- `EntityNotFitError` — Domain rule or constraint violations
+- `FailedToShareError` — Content-sharing failures
+- `TokenNotFoundError` — Authentication token not found
 
 In addition to the [AppError], there are a preset of foreseen [Exceptions].
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,11 +1,138 @@
-import 'package:convenience_types/errors/errors.dart';
-import 'package:convenience_types/types/form_field.dart' as form;
-import 'package:convenience_types/types/maybe.dart';
-import 'package:convenience_types/types/request_status.dart';
-import 'package:convenience_types/types/result.dart';
+// ignore_for_file: avoid_print, unused_local_variable
+
+import 'package:convenience_types/convenience_types.dart';
 import 'package:dio/dio.dart';
 import 'package:example/http_client_wrapper.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide FormField;
+
+// ---------------------------------------------------------------------------
+// 1. ValueObject – EmailAddress (uses Result + ValueError internally)
+// ---------------------------------------------------------------------------
+
+/// A self-validating email value object.
+///
+/// Demonstrates [ValueObject], [Result], and [InvalidEmail].
+class EmailAddress extends ValueObject<String> {
+  @override
+  final Result<String> value;
+
+  factory EmailAddress(String input) {
+    return EmailAddress._(
+      input.contains('@') && input.contains('.')
+          ? Success(input)
+          : Failure(InvalidEmail(
+              failedValue: input,
+              msg: 'Must contain @ and a dot',
+            )),
+    );
+  }
+
+  const EmailAddress._(this.value);
+}
+
+// ---------------------------------------------------------------------------
+// 2. UseCase – FetchNumberTrivia (uses UseCase, NoParams / custom Params,
+//    Result, Unit)
+// ---------------------------------------------------------------------------
+
+/// Input parameters for [FetchNumberTrivia].
+class FetchNumberTriviaParams {
+  final int number;
+  const FetchNumberTriviaParams(this.number);
+}
+
+/// A concrete [UseCase] that fetches trivia for a given number.
+///
+/// Demonstrates [UseCase], [Result], [HttpError], and [parseHttpError].
+class FetchNumberTrivia extends UseCase<NumberTrivia, FetchNumberTriviaParams> {
+  final HttpClientWrapper client;
+  const FetchNumberTrivia(this.client);
+
+  @override
+  Future<Result<NumberTrivia>> call(FetchNumberTriviaParams params) async {
+    return (await client.get(url: '${params.number}?json')).mapSuccess((data) {
+      try {
+        return Success(NumberTrivia.fromJson(data));
+      } catch (e) {
+        return Failure(ParseError(slug: e.toString()));
+      }
+    });
+  }
+}
+
+/// Simple model returned by the Numbers API.
+class NumberTrivia {
+  final String text;
+  final int number;
+  final String type;
+
+  const NumberTrivia(this.text, this.number, this.type);
+
+  factory NumberTrivia.fromJson(Map<String, dynamic> json) {
+    final text = json['text'];
+    final number = json['number'];
+    final type = json['type'];
+
+    if (text is! String || number is! int || type is! String) {
+      throw ParseException(
+          'Expected {text: String, number: int, type: String}');
+    }
+
+    return NumberTrivia(text, number, type);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Form with FormField + FormUtils + Validator
+// ---------------------------------------------------------------------------
+
+/// A tiny sign-up form that demonstrates [FormField], [FormUtils], and
+/// the [Validator] typedef.
+class SignUpForm with FormUtils {
+  final FormField<String> email;
+  final FormField<String> password;
+
+  const SignUpForm({
+    this.email = const FormField(name: 'email'),
+    this.password = const FormField(name: 'password'),
+  });
+
+  SignUpForm copyWith({
+    FormField<String>? email,
+    FormField<String>? password,
+  }) =>
+      SignUpForm(
+        email: email ?? this.email,
+        password: password ?? this.password,
+      );
+
+  // Validators ---------------------------------------------------------------
+
+  static String? _emailValidator(String value) =>
+      value.contains('@') && value.contains('.') ? null : 'Invalid email';
+
+  static String? _passwordMinLength(String value) =>
+      value.length >= 6 ? null : 'At least 6 characters';
+
+  // Validations that return Result<String> -----------------------------------
+
+  Result<String> get emailValidation => validateField(
+        field: email.field,
+        validators: [_emailValidator],
+      );
+
+  Result<String> get passwordValidation => validateField(
+        field: password.field,
+        validators: [_passwordMinLength],
+      );
+
+  /// Serialise only the fields that have been filled.
+  Map<String, dynamic> toJson() => fieldsToJson([email, password]);
+}
+
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
 
 void main() {
   runApp(const MyApp());
@@ -14,146 +141,337 @@ void main() {
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'Convenience Types — Full API Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        colorSchemeSeed: Colors.deepPurple,
+        useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Convenience Types Example'),
+      home: const DemoHome(),
     );
   }
 }
 
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({super.key, required this.title});
-
-  final String title;
+class DemoHome extends StatefulWidget {
+  const DemoHome({super.key});
 
   @override
-  State<MyHomePage> createState() => _MyHomePageState();
+  State<DemoHome> createState() => _DemoHomeState();
 }
 
-class _MyHomePageState extends State<MyHomePage> {
-  form.FormField<String> numberField = const form.FormField(name: 'number');
-  RequestStatus<Number> numberRequestStatus = const Idle();
-  Dio client = Dio(BaseOptions(
-      baseUrl: 'http://numbersapi.com/',
-      contentType: 'application/json; charset=utf-8'));
-  late HttpClientWrapper clientWrapper;
+class _DemoHomeState extends State<DemoHome> {
+  // -- Number trivia demo (UseCase + RequestStatus + HttpClientWrapper) ------
+  final Dio _dio = Dio(BaseOptions(
+    baseUrl: 'http://numbersapi.com/',
+    contentType: 'application/json; charset=utf-8',
+  ));
+  late final HttpClientWrapper _client = HttpClientWrapper(_dio);
+  late final FetchNumberTrivia _fetchTrivia = FetchNumberTrivia(_client);
+
+  FormField<String> _numberField = const FormField(name: 'number');
+  RequestStatus<NumberTrivia> _triviaStatus = const Idle();
+
+  // -- Sign-up form demo (FormField + FormUtils + Validator) -----------------
+  SignUpForm _form = const SignUpForm();
+
+  // -- Collected log lines ---------------------------------------------------
+  final List<String> _logLines = [];
+
+  void _log(String line) => setState(() => _logLines.add(line));
+
+  // --------------------------------------------------------------------------
+  // Lifecycle
+  // --------------------------------------------------------------------------
 
   @override
   void initState() {
     super.initState();
-    clientWrapper = HttpClientWrapper(client);
+    _runPureDartDemos();
   }
+
+  /// Runs a series of pure‐Dart demos on init and writes to [_logLines].
+  void _runPureDartDemos() {
+    _log('═══ Result ═══');
+    const Result<int> ok = Success(42);
+    const Result<int> err = Failure(AppUnknownError(slug: 'oops'));
+    _log('ok.isSuccess: ${ok.isSuccess}');
+    _log('err.isFailure: ${err.isFailure}');
+    _log(
+        'ok.handle → ${ok.handle(onSuccess: (d) => 'got $d', onFailure: (e) => e.slug)}');
+    _log('ok.mapSuccess → ${ok.mapSuccess((v) => Success(v * 2))}');
+    _log('err.mapFailure → ${err.mapFailure((e) => const Success(-1))}');
+    _log('ok.maybeData → ${ok.maybeData}');
+    _log('');
+
+    _log('═══ Maybe ═══');
+    const Maybe<String> name = Just('Alice');
+    const Maybe<String> empty = Nothing();
+    _log('name.isJust: ${name.isJust}');
+    _log('empty.isNothing: ${empty.isNothing}');
+    _log("name.getOrElse('?'): ${name.getOrElse('?')}");
+    _log("empty.getOrElse('?'): ${empty.getOrElse('?')}");
+    _log('Maybe.from(null): ${Maybe<String>.from(null)}');
+    _log('Maybe.from("hi"): ${Maybe.from("hi")}');
+    _log('Maybe.fromResult(ok): ${Maybe.fromResult(ok)}');
+    _log('name.mapJust → ${name.mapJust((v) => Just(v.length))}');
+    _log(
+        'empty.mapNothing → ${empty.mapNothing(() => const Just('fallback'))}');
+    _log('');
+
+    _log('═══ Maybe pair (maybeCombine) ═══');
+    const pair = (Just(10), Just('px'));
+    final combined = pair.maybeCombine<String>(
+      bothJust: (n, u) => Just('$n$u'),
+      firstJust: (n) => Just('$n'),
+      secondJust: (u) => Just(u),
+      bothNothing: () => const Just('–'),
+    );
+    _log('(Just(10), Just("px")).maybeCombine → $combined');
+    _log('');
+
+    _log('═══ Unit & identity ═══');
+    _log('Unit(): ${const Unit()}');
+    _log('identity(42): ${identity(42)}');
+    _log('');
+
+    _log('═══ RequestStatus ═══');
+    const RequestStatus<String> idle = Idle();
+    const loaded = Succeeded('data!');
+    const failed = Failed(FailedToCacheError(slug: 'cache'));
+    _log('idle.isIdle: ${idle.isIdle}');
+    _log('loaded.isSucceeded: ${loaded.isSucceeded}');
+    _log('loaded.maybeData: ${loaded.maybeData}');
+    _log('failed.isFailed: ${failed.isFailed}');
+    _log('RequestStatus.fromResult(ok): ${RequestStatus.fromResult(ok)}');
+    _log('Maybe.fromRequest(loaded): ${Maybe.fromRequest(loaded)}');
+    _log('');
+
+    _log('═══ ValueObject (EmailAddress) ═══');
+    final validEmail = EmailAddress('test@example.com');
+    final invalidEmail = EmailAddress('nope');
+    _log('valid.isValid: ${validEmail.isValid()}');
+    _log('valid.getOrCrash: ${validEmail.getOrCrash()}');
+    _log('invalid.isValid: ${invalidEmail.isValid()}');
+    _log('invalid.failureOrUnit: ${invalidEmail.failureOrUnit}');
+    try {
+      invalidEmail.getOrCrash();
+    } on UnexpectedValueError catch (e) {
+      _log('Caught UnexpectedValueError: $e');
+    }
+    _log('');
+
+    _log('═══ FormField + FormUtils + Validator ═══');
+    _form = _form.copyWith(
+      email: _form.email.copyWith(field: const Just('bad')),
+      password: _form.password.copyWith(field: const Just('12345')),
+    );
+    _log('emailValidation: ${_form.emailValidation}');
+    _log('passwordValidation: ${_form.passwordValidation}');
+    _log('toJson (partial): ${_form.toJson()}');
+    _form = _form.copyWith(
+      email: _form.email.copyWith(field: const Just('a@b.c')),
+      password: _form.password.copyWith(field: const Just('secure123')),
+    );
+    _log('emailValidation (fixed): ${_form.emailValidation}');
+    _log('toJson (full): ${_form.toJson()}');
+    _log('');
+
+    _log('═══ NoParams ═══');
+    _log('NoParams(): ${const NoParams()}');
+    _log('');
+
+    _log('═══ SizingInformation & ScreenType ═══');
+    _log('ScreenType.fromWidth(320): ${ScreenType.fromWidth(320)}');
+    _log('ScreenType.fromWidth(900): ${ScreenType.fromWidth(900)}');
+    _log('ScreenType.fromWidth(1920): ${ScreenType.fromWidth(1920)}');
+    _log('');
+
+    _log('═══ AppError hierarchy ═══');
+    const errors = <AppError>[
+      AppUnknownError(slug: 'unknown'),
+      ParseError(slug: 'parse'),
+      EntityNotFitError(slug: 'entity'),
+      FailedToShareError(slug: 'share'),
+      TokenNotFoundError(slug: 'token'),
+      HttpNotFoundError(slug: '404', msg: 'Not found'),
+      HttpBadRequestError(slug: '400'),
+      HttpUnauthorizedError(slug: '401'),
+      HttpForbiddenError(slug: '403'),
+      HttpGoneError(slug: '410'),
+      UnprocessableEntityError(slug: '422'),
+      HttpInternalServerError(slug: '500'),
+      HttpNetworkError(slug: 'net'),
+      HttpUnknownError(slug: 'http_unknown'),
+      NoInternetConnectionError(slug: 'offline'),
+      FailedToCacheError(slug: 'cache_write'),
+      FileAlreadyCachedError(slug: 'dup'),
+      NotCachedError(slug: 'miss'),
+      FailedToUnloadError(slug: 'unload'),
+      StorageUnknownError(slug: 'storage'),
+      StorageNotFoundError(slug: 'storage_404'),
+      FormError(slug: 'form'),
+      DeviceInfoUnknownError(slug: 'dev_unknown'),
+      DeviceInfoNotFoundError(slug: 'dev_404'),
+    ];
+    for (final e in errors) {
+      _log('  ${e.runtimeType} (slug: ${e.slug})');
+    }
+    _log('');
+
+    _log('═══ ValueError subclasses ═══');
+    const valErrors = <ValueError>[
+      InvalidEmail(failedValue: 'x'),
+      InvalidPassword(failedValue: 'x'),
+      InvalidUserName(failedValue: 'x'),
+      InvalidName(failedValue: 'x'),
+      InvalidOTP(failedValue: 'x'),
+      DescriptionTooShort(failedValue: 'x'),
+      DescriptionTooLong(failedValue: 'x'),
+      InsufficientDetail(failedValue: 'x'),
+      InvalidCharacters(failedValue: 'x'),
+    ];
+    for (final v in valErrors) {
+      _log('  ${v.runtimeType}');
+    }
+    _log('');
+
+    _log('═══ Exceptions ═══');
+    _log('ParseException: ${ParseException('bad json')}');
+    _log('CacheException: ${CacheException('disk full')}');
+    _log('');
+
+    _log('═══ DefaultErrorMessages ═══');
+    _log('unknownError: ${DefaultErrorMessages.unknownError}');
+    _log(
+        'noInternetConnectionError: ${DefaultErrorMessages.noInternetConnectionError}');
+    _log('waitCurrentRequest: ${DefaultErrorMessages.waitCurrentRequest}');
+    _log('');
+
+    _log('═══ AppError.maybeResponse ═══');
+    const httpErr = HttpNotFoundError<String>(
+      slug: '404',
+      response: Just('response body'),
+    );
+    _log('httpErr.maybeResponse<String>(): ${httpErr.maybeResponse<String>()}');
+    const appErr = AppUnknownError(slug: 'no_response');
+    _log('appErr.maybeResponse<String>(): ${appErr.maybeResponse<String>()}');
+    _log('');
+
+    _log('✅ All pure-Dart demos complete.');
+  }
+
+  // --------------------------------------------------------------------------
+  // Number trivia fetch (showcases UseCase + RequestStatus + HttpError)
+  // --------------------------------------------------------------------------
+  Future<void> _onFetchTrivia() async {
+    setState(() => _triviaStatus = const Loading());
+
+    final input = _numberField.field.getOrElse('42');
+    final numberValue = int.tryParse(input) ?? 42;
+
+    final result = await _fetchTrivia(FetchNumberTriviaParams(numberValue));
+
+    setState(() => _triviaStatus = RequestStatus.fromResult(result));
+  }
+
+  // --------------------------------------------------------------------------
+  // Build
+  // --------------------------------------------------------------------------
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(8.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              const Text(
-                'Enter a number to search for a trivia:',
+      appBar: AppBar(title: const Text('Convenience Types — Full API Demo')),
+      body: LayoutBuilder(
+        builder: (context, constraints) {
+          // Demonstrate SizingInformation
+          final sizing = SizingInformation(
+            screenType: ScreenType.fromWidth(constraints.maxWidth),
+            screenSize: Size(constraints.maxWidth, constraints.maxHeight),
+          );
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              // -- SizingInformation live readout -----------------------------
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(12),
+                  child: Text(
+                    'SizingInformation ▸ ${sizing.screenType.name} '
+                    '(${sizing.screenSize.width.toStringAsFixed(0)}×'
+                    '${sizing.screenSize.height.toStringAsFixed(0)})',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                ),
               ),
+              const SizedBox(height: 16),
+
+              // -- Number trivia section (UseCase + RequestStatus) ------------
+              Text('Number trivia (UseCase + RequestStatus)',
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
               TextField(
-                onChanged: _onFieldChanged,
+                decoration: const InputDecoration(
+                  labelText: 'Enter a number',
+                  border: OutlineInputBorder(),
+                ),
+                onChanged: (v) =>
+                    _numberField = _numberField.copyWith(field: Just(v)),
               ),
-              const SizedBox(
-                height: 8,
+              const SizedBox(height: 8),
+              FilledButton.icon(
+                onPressed: _onFetchTrivia,
+                icon: const Icon(Icons.search),
+                label: const Text('Fetch trivia'),
               ),
-              ElevatedButton(
-                onPressed: _onButtonPressed,
-                child: const Text('Search'),
-              ),
-              const SizedBox(
-                height: 8,
-              ),
-              switch (numberRequestStatus) {
-                Idle() => const SizedBox(),
+              const SizedBox(height: 8),
+              switch (_triviaStatus) {
+                Idle() => const SizedBox.shrink(),
                 Loading() => const LinearProgressIndicator(),
-                Succeeded(:final data) => Text(
-                    'You\'ve just searched ${data.number}, here is a trivia for it: ${data.text}!'),
-                Failed(:final error) =>
-                  Text('Something didn\'t go well! Sorry! hint: ${error.slug}'),
+                Succeeded(:final data) => Card(
+                    color: Colors.green.shade50,
+                    child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child:
+                          Text('${data.number} (${data.type}): ${data.text}'),
+                    ),
+                  ),
+                Failed(:final error) => Card(
+                    color: Colors.red.shade50,
+                    child: Padding(
+                      padding: const EdgeInsets.all(12),
+                      child: Text('Error: ${error.slug}'),
+                    ),
+                  ),
               },
+              const Divider(height: 32),
+
+              // -- Pure-Dart demo log ----------------------------------------
+              Text('Pure-Dart API demos (run on init)',
+                  style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: 8),
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade900,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: SelectableText(
+                  _logLines.join('\n'),
+                  style: const TextStyle(
+                    fontFamily: 'monospace',
+                    fontSize: 12,
+                    color: Colors.greenAccent,
+                  ),
+                ),
+              ),
             ],
-          ),
-        ),
+          );
+        },
       ),
     );
-  }
-
-  void _onFieldChanged(String value) {
-    numberField = numberField.copyWith(field: Just(value));
-  }
-
-  void _onButtonPressed() async {
-    setState(() {
-      numberRequestStatus = const Loading();
-    });
-
-    Result<Number> numberRes;
-
-    try {
-      numberRes = (await clientWrapper.get(
-              url: '${numberField.field.getOrElse('')}?json'))
-          .mapSuccess(_mapRequestToNumber);
-
-      numberRes = (await numberRes.mapAsyncSuccess((number) async =>
-              await clientWrapper.get(url: '${number.number * 2}?json')))
-          .mapSuccess(_mapRequestToNumber);
-    } catch (e) {
-      numberRes = Failure(
-        AppUnknownError(
-          slug: e.toString(),
-        ),
-      );
-    }
-
-    setState(() {
-      numberRequestStatus = RequestStatus.fromResult(numberRes);
-    });
-  }
-
-  Result<Number> _mapRequestToNumber(data) {
-    try {
-      return Success(Number.fromJson(data));
-    } catch (e) {
-      return Failure(HttpUnknownError(slug: e.toString()));
-    }
-  }
-}
-
-class Number {
-  final String text;
-  final int number;
-  final String type;
-
-  Number(
-    this.text,
-    this.number,
-    this.type,
-  );
-
-  factory Number.fromJson(Map<String, dynamic> json) {
-    try {
-      return Number(
-        json['text']!,
-        json['number']!,
-        json['type']!,
-      );
-    } catch (e) {
-      throw Exception(e);
-    }
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: b5e72753cf63becce2c61fd04dfe0f1c430cc5278b53a1342dc5ad839eab29ec
+      sha256: "33bae12a398f841c6cda09d1064212957265869104c478e5ad51e2fb26c3973c"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.5"
+    version: "7.0.0"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -71,7 +71,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.7.0"
+    version: "0.9.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -203,18 +203,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -320,10 +320,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   typed_data:
     dependency: transitive
     description:

--- a/lib/convenience_types.dart
+++ b/lib/convenience_types.dart
@@ -1,4 +1,18 @@
-// exporting types
+/// Convenience types, errors, and utilities commonly used across Flutter projects.
+///
+/// Import this single library to access the full public API:
+///
+/// **Types** — [Result], [Maybe], [Unit], [RequestStatus], [FormField],
+/// [SizingInformation], [NoParams], [ValueObject], [UseCase]
+///
+/// **Errors** — [AppError] and its subclasses ([HttpError], [CacheError],
+/// [StorageError], [FormError], [DeviceInfoError]), plus [ValueError] and its
+/// preset subclasses ([InvalidEmail], [InvalidPassword], etc.)
+///
+/// **Utilities** — [FormUtils] mixin, [SeedTestStateMixin],
+/// [identity] function, [Validator] typedef, [parseHttpError]
+library;
+
 export 'package:convenience_types/types/types.dart';
 export 'package:convenience_types/errors/errors.dart';
 export 'package:convenience_types/util/utils.dart';

--- a/lib/errors/app_error.dart
+++ b/lib/errors/app_error.dart
@@ -1,18 +1,36 @@
 import 'package:convenience_types/errors/http_error.dart';
 import 'package:convenience_types/types/maybe.dart';
 
-/// Abstract class to model errors on the application. As a presset of foreseen
-/// specific errors there are some different implementations of this type. Namely:
-/// [HttpError]  models errors related to http requests
-/// [CacheError]  models cache errors
-/// [DeviceInfoError]  models device's information gathering related errors
-/// [FormError]  models form related errors
-/// [StorageError]  models storage operations related errors
+/// Abstract base class for all application errors.
 ///
-/// In addition to the [AppError], there are a presset of foreseen [Exceptions]
+/// Provides a common interface for typed, structured error handling. All errors
+/// carry a [slug] (machine-readable identifier), a [msg] (human-readable
+/// message), and an optional [stackTrace].
+///
+/// Preset concrete subclasses cover the most common error domains:
+/// - [HttpError] — HTTP request failures (network, status codes, etc.)
+/// - [CacheError] — Local cache read/write failures
+/// - [DeviceInfoError] — Device information retrieval failures
+/// - [FormError] — Form validation and submission failures
+/// - [StorageError] — Device storage access failures
+///
+/// General-purpose subclasses are also provided:
+/// - [AppUnknownError] — Unexpected or unclassified errors
+/// - [ParseError] — Data parsing or deserialization failures
+/// - [EntityNotFitError] — Domain rule or constraint violations
+/// - [FailedToShareError] — Content-sharing failures
+/// - [TokenNotFoundError] — Authentication token not found
+///
+/// See also [ValueError] for value-validation errors, and the corresponding
+/// [ParseException] / [CacheException] for thrown exception counterparts.
 abstract class AppError {
+  /// A machine-readable identifier for this error (e.g. `'user_not_found'`).
   final String slug;
+
+  /// A human-readable description of this error.
   final String msg;
+
+  /// The stack trace associated with this error, if available.
   final String stackTrace;
 
   const AppError({
@@ -39,10 +57,15 @@ abstract class AppError {
   String toString() =>
       '[$runtimeType]: (slug: $slug, msg: $msg, stackTrace: $stackTrace,)';
 
+  /// If this error is an [HttpError]\<T>, returns [Just] with its typed
+  /// response body; otherwise returns [Nothing].
   Maybe<T> maybeResponse<T>() =>
       this is HttpError<T> ? (this as HttpError<T>).response : const Nothing();
 }
 
+/// An unexpected or unclassified application error.
+///
+/// Use when no more specific [AppError] subclass applies.
 class AppUnknownError extends AppError {
   const AppUnknownError({
     super.slug,
@@ -58,6 +81,7 @@ class AppUnknownError extends AppError {
         }''';
 }
 
+/// An error that occurred while parsing or deserializing data.
 class ParseError extends AppError {
   const ParseError({
     super.slug,
@@ -73,6 +97,7 @@ class ParseError extends AppError {
         }''';
 }
 
+/// An error indicating a domain entity failed to satisfy a constraint or rule.
 class EntityNotFitError extends AppError {
   const EntityNotFitError({
     super.slug,
@@ -88,6 +113,7 @@ class EntityNotFitError extends AppError {
         }''';
 }
 
+/// An error indicating a content-sharing operation failed.
 class FailedToShareError extends AppError {
   const FailedToShareError({
     super.slug,
@@ -103,6 +129,7 @@ class FailedToShareError extends AppError {
         }''';
 }
 
+/// An error indicating no authentication token was found.
 class TokenNotFoundError extends AppError {
   const TokenNotFoundError({
     super.slug,

--- a/lib/errors/cache_error.dart
+++ b/lib/errors/cache_error.dart
@@ -1,8 +1,10 @@
 import 'app_error.dart';
 
-/// Abstract class to model errors on the application. As a presset of foreseen
-/// specific errors there are some different implementations of this type.
-/// [CacheError] models cache errors
+/// Abstract base for cache-related errors.
+///
+/// Extend this class to represent specific failure modes when reading from or
+/// writing to a local cache. Concrete subclasses include [FailedToCacheError],
+/// [FileAlreadyCachedError], [NotCachedError], and [FailedToUnloadError].
 abstract class CacheError extends AppError {
   const CacheError({
     super.slug,
@@ -11,7 +13,7 @@ abstract class CacheError extends AppError {
   });
 }
 
-/// [FailedToCacheError] models failure in the action of caching an info
+/// An error arising from a failed attempt to cache data.
 class FailedToCacheError extends CacheError {
   const FailedToCacheError({
     super.slug,
@@ -23,7 +25,7 @@ class FailedToCacheError extends CacheError {
   String toString() => '[FailedToCacheError]: {slug: $slug, msg: $msg}';
 }
 
-/// [FileAlreadyCachedError] models failure araised from trying to cache an already cached file
+/// An error arising from attempting to cache data that is already cached.
 class FileAlreadyCachedError extends CacheError {
   const FileAlreadyCachedError({
     super.slug,
@@ -35,7 +37,7 @@ class FileAlreadyCachedError extends CacheError {
   String toString() => '[FileAlreadyCachedError]: {slug: $slug, msg: $msg}';
 }
 
-/// [NotCachedError] models failure araised from trying retrieve a file not yet cached
+/// An error arising from trying to retrieve data that has not been cached yet.
 class NotCachedError extends CacheError {
   const NotCachedError({
     super.slug,
@@ -47,7 +49,7 @@ class NotCachedError extends CacheError {
   String toString() => '[NotCachedError]: {slug: $slug, msg: $msg}';
 }
 
-/// [FailedToUnloadError] models failure araised from trying to delete a cached file
+/// An error arising from a failed attempt to delete a cached entry.
 class FailedToUnloadError extends CacheError {
   const FailedToUnloadError({
     super.slug,

--- a/lib/errors/default_error_messages.dart
+++ b/lib/errors/default_error_messages.dart
@@ -8,12 +8,30 @@ const String _NO_INTERNET_CONNECTION_MSG =
 
 const String _WAIT_CURRENT_REQUEST_MSG = 'Aguarde o final da tarefa.';
 
+/// Default user-facing error message strings (in Brazilian Portuguese).
+///
+/// These constants are used as fallback [AppError.msg] values throughout the
+/// package. You can supply custom messages by passing them directly to the
+/// relevant error constructors or to [parseHttpError].
 class DefaultErrorMessages {
+  /// Generic fallback message shown for unclassified errors.
   static const String unknownError = _GENERIC_ERROR_MSG;
+
+  /// Fallback message for cache-related failures.
   static const String cacheError = _GENERIC_ERROR_MSG;
+
+  /// Fallback message for content-sharing failures.
   static const String shareError = _GENERIC_ERROR_MSG;
+
+  /// Fallback message for storage-related failures.
   static const String storageError = _GENERIC_ERROR_MSG;
+
+  /// Fallback message for device information errors.
   static const String deviceError = _GENERIC_ERROR_MSG;
+
+  /// Message shown when there is no internet connection.
   static const String noInternetConnectionError = _NO_INTERNET_CONNECTION_MSG;
+
+  /// Message shown when a previous request has not yet completed.
   static const String waitCurrentRequest = _WAIT_CURRENT_REQUEST_MSG;
 }

--- a/lib/errors/device_info_error.dart
+++ b/lib/errors/device_info_error.dart
@@ -1,8 +1,9 @@
 import 'app_error.dart';
 
-/// Abstract class to model errors on the application. As a presset of foreseen
-/// specific errors there are some different implementations of this type.
-/// [DeviceInfoError] models device's information gathering related errors
+/// Abstract base for errors that occur while gathering device information.
+///
+/// Concrete subclasses include [DeviceInfoUnknownError] and
+/// [DeviceInfoNotFoundError].
 abstract class DeviceInfoError extends AppError {
   const DeviceInfoError({
     super.slug,
@@ -11,8 +12,7 @@ abstract class DeviceInfoError extends AppError {
   });
 }
 
-/// [DeviceInfoError] models device's information gathering error related
-/// to device info unknown or malformed
+/// An error indicating that the device information returned was unknown or malformed.
 class DeviceInfoUnknownError extends DeviceInfoError {
   const DeviceInfoUnknownError({
     super.slug,
@@ -21,8 +21,7 @@ class DeviceInfoUnknownError extends DeviceInfoError {
   });
 }
 
-/// [DeviceInfoError] models device's information gathering error related
-/// to device info not found
+/// An error indicating that the requested device information could not be found.
 class DeviceInfoNotFoundError extends DeviceInfoError {
   const DeviceInfoNotFoundError({
     super.slug,

--- a/lib/errors/exceptions.dart
+++ b/lib/errors/exceptions.dart
@@ -1,6 +1,16 @@
-/// [ParseException] models the exception to be thrown in case of an illegal
-/// operation happens during the process of parsing data,
-/// `Example: SomeModel.fromJson throw ParseException`
+/// Exception thrown when an illegal operation occurs during data parsing.
+///
+/// Typically thrown from a model's `fromJson` factory when deserialization
+/// fails. For error-type counterparts, see [ParseError].
+///
+/// Example:
+/// ```dart
+/// factory MyModel.fromJson(Map<String, dynamic> json) {
+///   final name = json['name'];
+///   if (name is! String) throw ParseException('Expected string for "name"');
+///   return MyModel(name: name);
+/// }
+/// ```
 class ParseException implements Exception {
   final String exception;
 
@@ -13,9 +23,9 @@ class ParseException implements Exception {
   ''';
 }
 
-/// [CacheException] models the exception to be thrown in case an illegal
-/// operation happens during caching request
-
+/// Exception thrown when an illegal operation occurs during a caching request.
+///
+/// For error-type counterparts, see [CacheError].
 class CacheException implements Exception {
   final String exception;
 

--- a/lib/errors/form_error.dart
+++ b/lib/errors/form_error.dart
@@ -1,6 +1,10 @@
 import 'app_error.dart';
 
-/// [FormError] models any error that might happen while operating with a form
+/// An error that occurred while validating or submitting a form.
+///
+/// Produced by [FormUtils.validateField] when a field fails one or more
+/// validators. The [AppError.msg] field carries the first validator error
+/// message.
 class FormError extends AppError {
   const FormError({
     super.slug,

--- a/lib/errors/http_error.dart
+++ b/lib/errors/http_error.dart
@@ -4,11 +4,23 @@ import 'package:dio/dio.dart';
 
 import 'app_error.dart';
 
-/// Abstract class to model errors on the application. As a presset of foreseen
-/// specific errors there are some different implementations of this type.
-/// [HttpError] models errors related to http requests
+/// Abstract base for HTTP request errors.
+///
+/// Carries the HTTP status [code] and an optional typed [response] body
+/// (as [Maybe]\<T>). Concrete subclasses map to specific failure modes:
+/// [HttpNetworkError], [HttpUnknownError], [HttpBadRequestError] (400),
+/// [HttpUnauthorizedError] (401), [HttpForbiddenError] (403),
+/// [HttpNotFoundError] (404), [HttpGoneError] (410),
+/// [UnprocessableEntityError] (422), [HttpInternalServerError] (500),
+/// and [NoInternetConnectionError].
+///
+/// Use [parseHttpError] to automatically map a [DioException] to the
+/// appropriate subclass.
 abstract class HttpError<T> extends AppError {
+  /// The HTTP status code associated with this error (default `-2` when unknown).
   final int code;
+
+  /// The optional typed response body returned alongside this error.
   final Maybe<T> response;
 
   const HttpError({
@@ -45,10 +57,12 @@ class HttpUnknownError<T> extends HttpError<T> {
   });
 }
 
-/// [HttpNetworkError] models http errors with `status 400`
+/// An HTTP 400 Bad Request error.
 class HttpBadRequestError<T> extends HttpError<T> {
+  /// Structured validation errors returned by the server.
   final Map<String, dynamic> errors;
 
+  /// Developer-facing message from the server's `msg_dev` field, if present.
   String get msgDev => errors['msg_dev'] ?? '';
 
   const HttpBadRequestError({
@@ -115,8 +129,10 @@ class HttpGoneError<T> extends HttpError<T> {
 /// [UnprocessableEntityError] models http errors with `status 422`
 
 class UnprocessableEntityError<T> extends HttpError<T> {
+  /// Structured validation errors returned by the server.
   final Map<String, dynamic> errors;
 
+  /// Developer-facing message from the server's `msg_dev` field, if present.
   String get msgDev => errors['msg_dev'] ?? '';
 
   const UnprocessableEntityError({
@@ -153,6 +169,22 @@ class NoInternetConnectionError<T> extends HttpError<T> {
   });
 }
 
+/// Maps a [DioException] to the most appropriate [HttpError] subclass.
+///
+/// - [stackTrace] is used for the error's stack trace field.
+/// - [slug] defaults to the request path or Dio's error message.
+/// - [handleErrorMessage] overrides the default message-extraction logic;
+///   when omitted, the server's `msg` JSON field is used if available.
+/// - [errorResponseSerializer] deserializes the raw response body into [T];
+///   the result is wrapped in a [Maybe] and stored in [HttpError.response].
+/// - [defaultErrorMessage] is the fallback human-readable message.
+/// - [defaultNoInternetConnectionMessage] overrides [defaultErrorMessage]
+///   specifically for connectivity errors; falls back to [defaultErrorMessage]
+///   when empty.
+///
+/// Connection-related errors (timeout, connection error, unknown) are
+/// delegated to [parseSocketException], which checks actual connectivity to
+/// differentiate between [NoInternetConnectionError] and [HttpNetworkError].
 Future<HttpError<T>> parseHttpError<T>({
   required DioException error,
   StackTrace stackTrace = StackTrace.empty,
@@ -279,6 +311,11 @@ Future<HttpError<T>> parseHttpError<T>({
   }
 }
 
+/// Resolves a connection-level [DioException] to [NoInternetConnectionError]
+/// or [HttpNetworkError] depending on actual device connectivity.
+///
+/// Uses `connectivity_plus` to check whether the device has an active network
+/// connection at the time of the error.
 Future<HttpError<T>> parseSocketException<T>({
   required String msg,
   required DioException exception,

--- a/lib/errors/storage_error.dart
+++ b/lib/errors/storage_error.dart
@@ -1,8 +1,10 @@
 import 'app_error.dart';
 
-/// Abstract class to model errors on the application. As a presset of foreseen
-/// specific errors there are some different implementations of this type.
-/// [StorageError] models errors related to storage operations
+/// Abstract base for storage-related errors.
+///
+/// Extend this class to represent specific failure modes when accessing or
+/// managing device storage. Concrete subclasses include [StorageUnknownError]
+/// and [StorageNotFoundError].
 abstract class StorageError extends AppError {
   const StorageError({
     super.slug,
@@ -11,7 +13,7 @@ abstract class StorageError extends AppError {
   });
 }
 
-/// [StorageUnknownError] models unknown or unexpected storage related errors
+/// An unknown or unexpected storage-related error.
 class StorageUnknownError extends StorageError {
   const StorageUnknownError({
     super.slug,
@@ -20,7 +22,7 @@ class StorageUnknownError extends StorageError {
   });
 }
 
-/// [StorageNotFoundError] models the error of not finding device's storage
+/// An error indicating that the device storage could not be found.
 
 class StorageNotFoundError extends StorageError {
   const StorageNotFoundError({

--- a/lib/errors/value_errors.dart
+++ b/lib/errors/value_errors.dart
@@ -8,7 +8,7 @@ abstract class ValueError extends AppError {
 
 /// Thrown when a [ValueObject] is read via [ValueObject.getOrCrash] and its [Result] is [Failure].
 ///
-/// Holds the failing [value] ([Result]<T>) and optional [msg], [slug], [stackTrace].
+/// Holds the failing [value] ([Result]\<T>) and optional [msg], [slug], [stackTrace].
 class UnexpectedValueError<T> extends ValueError {
   final Result<T> value;
 
@@ -25,6 +25,7 @@ class UnexpectedValueError<T> extends ValueError {
 
 /// Email failed validation.
 class InvalidEmail extends ValueError {
+  /// The value that failed email validation.
   final String failedValue;
 
   const InvalidEmail({
@@ -40,6 +41,7 @@ class InvalidEmail extends ValueError {
 
 /// Password failed validation.
 class InvalidPassword extends ValueError {
+  /// The value that failed password validation.
   final String failedValue;
 
   const InvalidPassword({
@@ -55,6 +57,7 @@ class InvalidPassword extends ValueError {
 
 /// User name failed validation.
 class InvalidUserName extends ValueError {
+  /// The value that failed username validation.
   final String failedValue;
 
   const InvalidUserName({
@@ -70,6 +73,7 @@ class InvalidUserName extends ValueError {
 
 /// Name failed validation.
 class InvalidName extends ValueError {
+  /// The value that failed name validation.
   final String failedValue;
 
   const InvalidName({
@@ -85,6 +89,7 @@ class InvalidName extends ValueError {
 
 /// OTP (one-time password) failed validation.
 class InvalidOTP extends ValueError {
+  /// The value that failed OTP validation.
   final String failedValue;
 
   const InvalidOTP({
@@ -100,6 +105,7 @@ class InvalidOTP extends ValueError {
 
 /// Description length below minimum.
 class DescriptionTooShort extends ValueError {
+  /// The value whose length was too short.
   final String failedValue;
 
   const DescriptionTooShort({
@@ -112,6 +118,7 @@ class DescriptionTooShort extends ValueError {
 
 /// Description length above maximum.
 class DescriptionTooLong extends ValueError {
+  /// The value whose length was too long.
   final String failedValue;
 
   const DescriptionTooLong({
@@ -124,6 +131,7 @@ class DescriptionTooLong extends ValueError {
 
 /// Detail/content insufficient for validation.
 class InsufficientDetail extends ValueError {
+  /// The value that provided insufficient detail.
   final String failedValue;
 
   const InsufficientDetail({
@@ -136,6 +144,7 @@ class InsufficientDetail extends ValueError {
 
 /// Value contains disallowed characters.
 class InvalidCharacters extends ValueError {
+  /// The value that contained invalid characters.
   final String failedValue;
 
   const InvalidCharacters({

--- a/lib/types/form_field.dart
+++ b/lib/types/form_field.dart
@@ -5,9 +5,9 @@ part 'form_field.freezed.dart';
 
 /// When providing data to a form and then passing it forward, for instance,
 /// in a request body, one problem that is common here is the need of dealing
-/// with the cases where the field is not filled, and than one might need to
-/// treat every possible resulting Map (json) separetily, either passing the not
-/// filled field with no value or not passing it at all. <br>
+/// with the cases where the field is not filled, and then one might need to
+/// treat every possible resulting Map (json) separately, either passing the not
+/// filled field with no value or not passing it at all.
 ///
 /// The generic sealed data class
 /// ```dart
@@ -94,7 +94,7 @@ part 'form_field.freezed.dart';
 /// ```
 ///
 /// Using a `Form` class as presented, one has a safe way to pass the values of
-/// the field to a request body with easy. <br>
+/// the field to a request body with ease.
 /// Example:
 /// ```dart
 ///   request.body = formExampleInstance.toJson(),

--- a/lib/types/request_status.dart
+++ b/lib/types/request_status.dart
@@ -4,28 +4,18 @@ import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'request_status.freezed.dart';
 
-/// When one is dealing with ui responses to different request states, in the course of it,
-/// usually there are four states of interest [Idle], [Loading], [Succeded] or [Failed].
+/// A type-safe way to model the lifecycle of an asynchronous request in the UI.
 ///
-/// So the convenience generic union type
-/// ```dart
-/// RequestStatus<ResultType>
-/// ```
-/// serves the purpose of modeling those states. [Idle] and [Loading], carry no inner state, but
-/// ```dart
-/// Succeeded<ResultType>().data = ResultType data;
-/// ```
-/// contains a field `data` of type `ResultType`. And the
-/// ```dart
-/// Failed().error = AppError error;
-/// ```
-/// contains a field `error` of type `AppError`. Where `AppError` is the convenience type
-/// that models errors in the app.
+/// [RequestStatus]\<ResultType> is a union type with four states:
+/// - [Idle] — the request has not been fired yet
+/// - [Loading] — the request is in flight
+/// - [Succeeded]\<ResultType> — the request completed successfully; carries [data]
+/// - [Failed] — the request failed; carries an [AppError]
 ///
+/// Use [RequestStatus.fromResult] to build a status directly from a [Result].
 ///
-/// To deal with the request states one should use one of the unions methods.
-/// The `.map` forces you to deal with all the four states explicitly, passing callbacks for
-/// each state with undestructured states.
+/// To deal with the request states one should use Dart's native pattern matching.
+/// The `switch` statement or expression forces you to deal with all four states explicitly.
 ///
 /// Example:
 /// ```dart
@@ -34,41 +24,18 @@ part 'request_status.freezed.dart';
 ///
 ///     final someRequestStatus = someStateManagement.desiredRequestStatus;
 ///
-///     return someRequestStatus.map(
-///               idle: (idle) => "widget for idle state",
-///               loading: (loading) => "widget for loading state",
-///               succeeded: (succeeded) => "widget for succeeded state using possibly data within succeeded.data",
-///               failed: (failed) => "widget for failed state using possibly AppError within failed.error",
-///           );
+///     return switch (someRequestStatus) {
+///       Idle() => const Text("widget for idle state"),
+///       Loading() => const Text("widget for loading state"),
+///       Succeeded(:final data) => Text("widget for succeeded state using $data"),
+///       Failed(:final error) => Text("widget for failed state using ${error.msg}"),
+///     };
 ///
 ///   }
 ///
-///
-/// ```
-/// The `.when` forces you to deal with all the four states explicitly, passing callbacks for
-/// each state with destructured states.
-/// /// Example:
-/// ```dart
-///
-///   Widget build(context) {
-///
-///     final someRequestStatus = someStateManagement.desiredRequestStatus;
-///
-///     return someRequestStatus.when(
-///               idle: () => "widget for idle state",
-///               loading: () => "widget for loading state",
-///               succeeded: (data) => "widget for succeeded state using possibly data within data",
-///               failed: (error) => "widget for failed state using possibly AppError within error",
-///           );
-///
-///   }
-///
-///
 /// ```
 ///
-/// and one also might want to not deal explicitly with all states diferently, so
-/// there are the `.maybeMap`, and `.maybeWhen` methods where you need only expclitly to pass a
-/// `orElse` callback.
+/// You can also handle only the states you care about using a default case `_`:
 ///
 /// Example:
 /// ```dart
@@ -77,14 +44,13 @@ part 'request_status.freezed.dart';
 ///
 ///     final someRequestStatus = someStateManagement.desiredRequestStatus;
 ///
-///     return someRequestStatus.maybeWhen(
-///               orElse: () => "default widget to be displayed other wise the current state is not specified in other callbacks"
-///               loading: () => "widget for loading state",
-///               succeeded: (data) => "widget for succeeded state using possibly data within succeeded.data",
-///           );
+///     return switch (someRequestStatus) {
+///       Loading() => const Text("widget for loading state"),
+///       Succeeded(:final data) => Text("widget for succeeded state using $data"),
+///       _ => const Text("default widget to be displayed otherwise"),
+///     };
 ///
 ///   }
-///
 ///
 /// ```
 ///
@@ -119,9 +85,16 @@ sealed class RequestStatus<ResultType> with _$RequestStatus<ResultType> {
         _ => Nothing<ResultType>(),
       };
 
+  /// True if this is [Idle].
   bool get isIdle => this is Idle;
+
+  /// True if this is [Loading].
   bool get isLoading => this is Loading;
+
+  /// True if this is [Succeeded].
   bool get isSucceeded => this is Succeeded;
+
+  /// True if this is [Failed].
   bool get isFailed => this is Failed;
 
   /// Cast [this] into an [Idle], and throw an exception if the cast fails!

--- a/lib/util/form_utils.dart
+++ b/lib/util/form_utils.dart
@@ -3,11 +3,18 @@ import 'package:convenience_types/types/form_field.dart';
 import 'package:convenience_types/types/maybe.dart';
 import 'package:convenience_types/types/result.dart';
 
+/// A validation function for a form field of type [T].
+///
+/// Returns a non-null error message string when validation fails, or `null`
+/// when the value is valid. Used with [FormUtils.validateField].
 typedef Validator<T> = String? Function(T);
 
-/// Class used as a dart `Mixin` to a `Form` class, providing methods to conviniently
-/// deal with validation and serialization of fields.
+/// Mixin for form classes that provides convenient field validation and JSON
+/// serialization.
 ///
+/// Mix this into a form class alongside your [FormField] definitions, then
+/// call [validateField] for per-field validation and [fieldsToJson] to
+/// serialize only the filled fields into a `Map`.
 mixin class FormUtils {
   /// Method to help validate a [FormField<T>] providing its value represented by its `Maybe<T>`, and
   /// a `List<Validator<T>>`, returning a `Result<String>` with possible error message.

--- a/lib/util/utils.dart
+++ b/lib/util/utils.dart
@@ -1,1 +1,2 @@
 export 'package:convenience_types/util/form_utils.dart';
+export 'package:convenience_types/util/seed_test_state_mixin.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dev_dependencies:
   flutter_lints: ^6.0.0
   build_runner: ^2.11.0
   freezed: ^3.2.5
+  mocktail: ^1.0.4
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/test/errors/app_error_test.dart
+++ b/test/errors/app_error_test.dart
@@ -1,0 +1,87 @@
+import 'package:convenience_types/errors/app_error.dart';
+import 'package:convenience_types/errors/http_error.dart';
+import 'package:convenience_types/types/maybe.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestAppError extends AppError {
+  const _TestAppError({super.slug, super.msg, super.stackTrace});
+}
+
+void main() {
+  group('AppError base class', () {
+    test('== operator compares by slug and runtimeType', () {
+      const e1 = _TestAppError(slug: 'error-1', msg: 'A');
+      const e2 = _TestAppError(slug: 'error-1', msg: 'B');
+      const e3 = _TestAppError(slug: 'error-2', msg: 'A');
+      const eOther = AppUnknownError(slug: 'error-1');
+
+      expect(e1 == e2, true); // Same slug, same type
+      expect(e1 == e3, false); // Different slug
+      expect(e1 == eOther, false); // Different type
+    });
+
+    test('hashCode is consistent with ==', () {
+      const e1 = _TestAppError(slug: 'error-1', msg: 'A');
+      const e2 = _TestAppError(slug: 'error-1', msg: 'B');
+
+      expect(e1.hashCode == e2.hashCode, false); // Hash uses msg/stackTrace too
+      expect(
+        e1.hashCode,
+        const _TestAppError(slug: 'error-1', msg: 'A').hashCode,
+      );
+    });
+
+    test('toString includes slug, msg, and stackTrace', () {
+      const e = _TestAppError(slug: 'my-slug', msg: 'my-msg', stackTrace: 'st');
+      expect(
+        e.toString(),
+        '[_TestAppError]: (slug: my-slug, msg: my-msg, stackTrace: st,)',
+      );
+    });
+
+    group('maybeResponse', () {
+      test('Returns Nothing for non-HttpError', () {
+        const e = _TestAppError();
+        expect(e.maybeResponse<String>(), isA<Nothing>());
+      });
+
+      test('Returns Just with response when error is an HttpError', () {
+        const httpError = HttpNotFoundError<String>(response: Just('data'));
+        expect(httpError.maybeResponse<String>(), const Just('data'));
+      });
+    });
+  });
+
+  group('Concrete generic AppError subclasses', () {
+    test('AppUnknownError', () {
+      const e = AppUnknownError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.toString().contains('[AppUnknownError]'), true);
+      expect(e.toString().contains('slug: s'), true);
+    });
+
+    test('ParseError', () {
+      const e = ParseError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.toString().contains('[ParseError]'), true);
+    });
+
+    test('EntityNotFitError', () {
+      const e = EntityNotFitError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.toString().contains('[EntityNotFitError]'), true);
+    });
+
+    test('FailedToShareError', () {
+      const e = FailedToShareError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.toString().contains('[FailedToShareError]'), true);
+    });
+
+    test('TokenNotFoundError', () {
+      const e = TokenNotFoundError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.toString().contains('[NotFoundError]'), true);
+    });
+  });
+}

--- a/test/errors/cache_error_test.dart
+++ b/test/errors/cache_error_test.dart
@@ -1,0 +1,31 @@
+import 'package:convenience_types/errors/cache_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CacheError subclasses', () {
+    test('FailedToCacheError', () {
+      const e = FailedToCacheError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.stackTrace, 't');
+      expect(e.toString(), '[FailedToCacheError]: {slug: s, msg: m}');
+    });
+
+    test('FileAlreadyCachedError', () {
+      const e = FileAlreadyCachedError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.toString(), '[FileAlreadyCachedError]: {slug: s, msg: m}');
+    });
+
+    test('NotCachedError', () {
+      const e = NotCachedError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.toString(), '[NotCachedError]: {slug: s, msg: m}');
+    });
+
+    test('FailedToUnloadError', () {
+      const e = FailedToUnloadError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.toString(), '[FailedToUnloadError]: {slug: s, msg: m}');
+    });
+  });
+}

--- a/test/errors/default_error_messages_test.dart
+++ b/test/errors/default_error_messages_test.dart
@@ -1,0 +1,16 @@
+import 'package:convenience_types/errors/default_error_messages.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DefaultErrorMessages constants', () {
+    test('Are non-empty strings', () {
+      expect(DefaultErrorMessages.unknownError.isNotEmpty, true);
+      expect(DefaultErrorMessages.cacheError.isNotEmpty, true);
+      expect(DefaultErrorMessages.shareError.isNotEmpty, true);
+      expect(DefaultErrorMessages.storageError.isNotEmpty, true);
+      expect(DefaultErrorMessages.deviceError.isNotEmpty, true);
+      expect(DefaultErrorMessages.noInternetConnectionError.isNotEmpty, true);
+      expect(DefaultErrorMessages.waitCurrentRequest.isNotEmpty, true);
+    });
+  });
+}

--- a/test/errors/device_info_error_test.dart
+++ b/test/errors/device_info_error_test.dart
@@ -1,0 +1,20 @@
+import 'package:convenience_types/errors/device_info_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('DeviceInfoError subclasses', () {
+    test('DeviceInfoUnknownError', () {
+      const e = DeviceInfoUnknownError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.msg, 'm');
+      expect(e.stackTrace, 't');
+    });
+
+    test('DeviceInfoNotFoundError', () {
+      const e = DeviceInfoNotFoundError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.msg, 'm');
+      expect(e.stackTrace, 't');
+    });
+  });
+}

--- a/test/errors/exceptions_test.dart
+++ b/test/errors/exceptions_test.dart
@@ -1,0 +1,18 @@
+import 'package:convenience_types/errors/exceptions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Exceptions', () {
+    test('ParseException', () {
+      final e = ParseException('bad json');
+      expect(e.exception, 'bad json');
+      expect(e.toString().contains('bad json'), true);
+    });
+
+    test('CacheException', () {
+      final e = CacheException('disk full');
+      expect(e.exception, 'disk full');
+      expect(e.toString().contains('disk full'), true);
+    });
+  });
+}

--- a/test/errors/form_error_test.dart
+++ b/test/errors/form_error_test.dart
@@ -1,0 +1,13 @@
+import 'package:convenience_types/errors/form_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FormError', () {
+    test('Construction', () {
+      const e = FormError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.msg, 'm');
+      expect(e.stackTrace, 't');
+    });
+  });
+}

--- a/test/errors/http_error_test.dart
+++ b/test/errors/http_error_test.dart
@@ -1,0 +1,192 @@
+import 'dart:convert';
+import 'package:convenience_types/errors/http_error.dart';
+import 'package:convenience_types/types/maybe.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+// --- Mocks ---
+class MockDioException extends Mock implements DioException {}
+
+class MockRequestOptions extends Mock implements RequestOptions {}
+
+class MockResponse<T> extends Mock implements Response<T> {}
+
+class MockHeaders extends Mock implements Headers {}
+
+void main() {
+  group('HttpError concrete subclasses', () {
+    test('HttpNetworkError', () {
+      const e = HttpNetworkError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.code, -2); // Default
+    });
+
+    test('HttpUnknownError', () {
+      const e = HttpUnknownError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.code, -2);
+    });
+
+    test('HttpBadRequestError', () {
+      const e = HttpBadRequestError(
+        slug: 's',
+        msg: 'm',
+        errors: {'msg_dev': 'dev issue'},
+      );
+      expect(e.code, 400);
+      expect(e.msgDev, 'dev issue');
+    });
+
+    test('HttpUnauthorizedError', () {
+      const e = HttpUnauthorizedError();
+      expect(e.code, 401);
+    });
+
+    test('HttpForbiddenError', () {
+      const e = HttpForbiddenError();
+      expect(e.code, 403);
+    });
+
+    test('HttpNotFoundError', () {
+      const e = HttpNotFoundError();
+      expect(e.code, 404);
+    });
+
+    test('HttpGoneError', () {
+      const e = HttpGoneError();
+      expect(e.code, 410);
+    });
+
+    test('UnprocessableEntityError', () {
+      const e = UnprocessableEntityError(
+        errors: {'msg_dev': 'validation failed'},
+      );
+      expect(e.code, 422);
+      expect(e.msgDev, 'validation failed');
+    });
+
+    test('HttpInternalServerError', () {
+      const e = HttpInternalServerError();
+      expect(e.code, 500);
+    });
+
+    test('NoInternetConnectionError', () {
+      const e = NoInternetConnectionError();
+      expect(e.code, -2);
+    });
+  });
+
+  group('parseHttpError mapping', () {
+    late MockDioException mockDioException;
+    late MockRequestOptions mockRequestOptions;
+
+    setUp(() {
+      mockDioException = MockDioException();
+      mockRequestOptions = MockRequestOptions();
+      when(() => mockDioException.requestOptions).thenReturn(mockRequestOptions);
+      when(() => mockRequestOptions.path).thenReturn('/api/test');
+      when(() => mockDioException.message).thenReturn(null);
+      when(() => mockDioException.stackTrace).thenReturn(StackTrace.empty);
+    });
+
+    Future<void> runStatusTest(int statusCode, Type expectedTypeError) async {
+      final mockResponse = MockResponse<dynamic>();
+      when(() => mockResponse.statusCode).thenReturn(statusCode);
+      when(() => mockResponse.data).thenReturn({'msg': 'error msg'});
+
+      final mockHeaders = MockHeaders();
+      when(() => mockResponse.headers).thenReturn(mockHeaders);
+      when(() => mockHeaders.value('Content-Type')).thenReturn('application/json');
+
+      when(() => mockDioException.type).thenReturn(DioExceptionType.badResponse);
+      when(() => mockDioException.response).thenReturn(mockResponse);
+
+      final result = await parseHttpError(error: mockDioException);
+
+      expect(result.runtimeType.toString(), startsWith(expectedTypeError.toString()));
+      expect(result.msg, 'error msg');
+      expect(result.slug, '/api/test');
+    }
+
+    test('Maps HTTP 400 to HttpBadRequestError', () => runStatusTest(400, HttpBadRequestError));
+    test('Maps HTTP 401 to HttpUnauthorizedError', () => runStatusTest(401, HttpUnauthorizedError));
+    test('Maps HTTP 403 to HttpForbiddenError', () => runStatusTest(403, HttpForbiddenError));
+    test('Maps HTTP 404 to HttpNotFoundError', () => runStatusTest(404, HttpNotFoundError));
+    test('Maps HTTP 410 to HttpGoneError', () => runStatusTest(410, HttpGoneError));
+    test('Maps HTTP 422 to UnprocessableEntityError', () => runStatusTest(422, UnprocessableEntityError));
+    test('Maps HTTP 500 to HttpInternalServerError', () => runStatusTest(500, HttpInternalServerError));
+    test('Maps unhandled status code to HttpUnknownError', () => runStatusTest(418, HttpUnknownError));
+
+    test('Uses defaultErrorMessage when response has no msg', () async {
+      final mockResponse = MockResponse<dynamic>();
+      when(() => mockResponse.statusCode).thenReturn(404);
+      when(() => mockResponse.data).thenReturn({}); // Empty resp
+
+      final mockHeaders = MockHeaders();
+      when(() => mockResponse.headers).thenReturn(mockHeaders);
+      when(() => mockHeaders.value('Content-Type')).thenReturn('application/json');
+
+      when(() => mockDioException.type).thenReturn(DioExceptionType.badResponse);
+      when(() => mockDioException.response).thenReturn(mockResponse);
+
+      final result = await parseHttpError(
+        error: mockDioException,
+        defaultErrorMessage: 'fallback',
+      );
+
+      expect(result.msg, 'fallback');
+      expect(result.runtimeType.toString(), startsWith('HttpNotFoundError'));
+    });
+
+    test('Uses handleErrorMessage callback when provided', () async {
+      final mockResponse = MockResponse<dynamic>();
+      when(() => mockResponse.statusCode).thenReturn(400);
+      when(() => mockResponse.data).thenReturn(<String, dynamic>{});
+
+      final mockHeaders = MockHeaders();
+      when(() => mockResponse.headers).thenReturn(mockHeaders);
+      when(() => mockHeaders.value('Content-Type')).thenReturn('application/json');
+
+      when(() => mockDioException.type).thenReturn(DioExceptionType.badResponse);
+      when(() => mockDioException.response).thenReturn(mockResponse);
+
+      final result = await parseHttpError(
+        error: mockDioException,
+        handleErrorMessage: ({required error}) => 'custom msg',
+      );
+
+      expect(result.msg, 'custom msg');
+    });
+
+    test('Maps response data using errorResponseSerializer', () async {
+      final mockResponse = MockResponse<dynamic>();
+      when(() => mockResponse.statusCode).thenReturn(400);
+      when(() => mockResponse.data).thenReturn('{"foo":"bar"}');
+      when(() => mockResponse.headers).thenReturn(MockHeaders());
+
+      when(() => mockDioException.type).thenReturn(DioExceptionType.badResponse);
+      when(() => mockDioException.response).thenReturn(mockResponse);
+
+      final result = await parseHttpError<Map<String, dynamic>>(
+        error: mockDioException,
+        errorResponseSerializer: (data) => jsonDecode(data as String) as Map<String, dynamic>,
+      );
+
+      expect((result.response as Just<Map<String, dynamic>>).value['foo'], 'bar');
+    });
+  });
+
+  group('parseSocketException logic', () {
+    test('parseHttpError catches errors and falls back to HttpUnknownError', () async {
+      final mockError = MockDioException();
+      when(() => mockError.requestOptions).thenThrow(Exception('Simulated error'));
+      when(() => mockError.message).thenReturn(null);
+      
+      final result = await parseHttpError(
+        error: mockError,
+        defaultErrorMessage: 'caught',
+      );
+      expect(result, isA<HttpUnknownError>());
+      expect(result.msg, 'caught');
+    });
+  });
+}

--- a/test/errors/storage_error_test.dart
+++ b/test/errors/storage_error_test.dart
@@ -1,0 +1,20 @@
+import 'package:convenience_types/errors/storage_error.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('StorageError subclasses', () {
+    test('StorageUnknownError', () {
+      const e = StorageUnknownError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.msg, 'm');
+      expect(e.stackTrace, 't');
+    });
+
+    test('StorageNotFoundError', () {
+      const e = StorageNotFoundError(slug: 's', msg: 'm', stackTrace: 't');
+      expect(e.slug, 's');
+      expect(e.msg, 'm');
+      expect(e.stackTrace, 't');
+    });
+  });
+}

--- a/test/errors/value_errors_test.dart
+++ b/test/errors/value_errors_test.dart
@@ -1,0 +1,71 @@
+import 'package:convenience_types/errors/value_errors.dart';
+import 'package:convenience_types/types/result.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ValueError subclasses', () {
+    test('UnexpectedValueError', () {
+      const result = Failure<String>(InvalidEmail(failedValue: 'x'));
+      const e = UnexpectedValueError<String>(
+        result,
+        msg: 'm',
+        slug: 's',
+        stackTrace: 't',
+      );
+
+      expect(e.value, result);
+      expect(e.slug, 's');
+      expect(e.toString(), 'UnexpectedValueError: $result');
+    });
+
+    test('InvalidEmail', () {
+      const e = InvalidEmail(failedValue: 'bad', slug: 's', msg: 'm');
+      expect(e.failedValue, 'bad');
+      expect(e.toString(), 'InvalidEmail: bad');
+    });
+
+    test('InvalidPassword', () {
+      const e = InvalidPassword(failedValue: 'bad', slug: 's', msg: 'm');
+      expect(e.failedValue, 'bad');
+      expect(e.toString(), 'InvalidPassword: bad');
+    });
+
+    test('InvalidUserName', () {
+      const e = InvalidUserName(failedValue: 'bad', slug: 's', msg: 'm');
+      expect(e.failedValue, 'bad');
+      expect(e.toString(), 'InvalidUserName: bad');
+    });
+
+    test('InvalidName', () {
+      const e = InvalidName(failedValue: 'bad', slug: 's', msg: 'm');
+      expect(e.failedValue, 'bad');
+      expect(e.toString(), 'InvalidName: bad');
+    });
+
+    test('InvalidOTP', () {
+      const e = InvalidOTP(failedValue: 'bad', slug: 's', msg: 'm');
+      expect(e.failedValue, 'bad');
+      expect(e.toString(), 'InvalidOTP: bad');
+    });
+
+    test('DescriptionTooShort', () {
+      const e = DescriptionTooShort(failedValue: 'bad', slug: 's', msg: 'm');
+      expect(e.failedValue, 'bad');
+    });
+
+    test('DescriptionTooLong', () {
+      const e = DescriptionTooLong(failedValue: 'bad', slug: 's', msg: 'm');
+      expect(e.failedValue, 'bad');
+    });
+
+    test('InsufficientDetail', () {
+      const e = InsufficientDetail(failedValue: 'bad', slug: 's', msg: 'm');
+      expect(e.failedValue, 'bad');
+    });
+
+    test('InvalidCharacters', () {
+      const e = InvalidCharacters(failedValue: 'bad', slug: 's', msg: 'm');
+      expect(e.failedValue, 'bad');
+    });
+  });
+}

--- a/test/types/form_field_test.dart
+++ b/test/types/form_field_test.dart
@@ -20,4 +20,21 @@ void main() {
       );
     },
   );
+
+  group('castInto Nothing', () {
+    test('Fields with nothing remain nothing', () {
+      FormField<String> testFormField = const FormField(name: 'test', field: Nothing());
+      FormField<double> castedField = testFormField.castInto(
+          combiner: (input) => Maybe.from(double.tryParse(input)));
+      expect(castedField.field, const Nothing<double>());
+    });
+  });
+
+  group('default field', () {
+    test('field defaults to Nothing if not provided', () {
+      FormField<String> testFormField = const FormField(name: 'test');
+      expect(testFormField.field, isA<Nothing>());
+    });
+  });
 }
+

--- a/test/types/maybe_test.dart
+++ b/test/types/maybe_test.dart
@@ -310,4 +310,58 @@ void main() {
       );
     },
   );
+
+  group('mapNothing', () {
+    test('Returns the same maybe when Just', () {
+      expect(const Just('a').mapNothing(() => const Just('b')), const Just('a'));
+    });
+    test('Applies combiner when Nothing', () {
+      expect(const Nothing<String>().mapNothing(() => const Just('b')), const Just('b'));
+    });
+  });
+
+  group('mapAsyncNothing', () {
+    test('Returns the same maybe when Just', () async {
+      expect(await const Just('a').mapAsyncNothing(() async => const Just('b')), const Just('a'));
+    });
+    test('Applies combiner when Nothing', () async {
+      expect(await const Nothing<String>().mapAsyncNothing(() async => const Just('b')), const Just('b'));
+    });
+  });
+
+  group('isNothing and isJust', () {
+    test('isNothing is true for Nothing and false for Just', () {
+      expect(const Nothing().isNothing, true);
+      expect(const Just(1).isNothing, false);
+    });
+    test('isJust is true for Just and false for Nothing', () {
+      expect(const Just(1).isJust, true);
+      expect(const Nothing().isJust, false);
+    });
+  });
+
+  group('maybeAsyncCombine', () {
+    Future<Maybe<String>> firstJust(int val) async => Just(val.toString());
+    Future<Maybe<String>> secondJust(bool val) async => Just(val.toString());
+    Future<Maybe<String>> bothJust(int number, bool val) async => Just('$number${val.toString()}');
+    Future<Maybe<String>> bothNothing() async => const Just('bothNothing');
+
+    test('It should resolve bothJust', () async {
+      var testRecord = (const Just(1), const Just(true));
+      expect(await testRecord.maybeAsyncCombine(bothJust: bothJust), const Just('1true'));
+    });
+    test('It should resolve firstJust', () async {
+      var testRecord = (const Just(1), const Nothing());
+      expect(await testRecord.maybeAsyncCombine(firstJust: firstJust), const Just('1'));
+    });
+    test('It should resolve secondJust', () async {
+      var testRecord = (const Nothing(), const Just(true));
+      expect(await testRecord.maybeAsyncCombine(secondJust: secondJust), const Just('true'));
+    });
+    test('It should resolve bothNothing', () async {
+      var testRecord = (const Nothing(), const Nothing());
+      expect(await testRecord.maybeAsyncCombine(bothNothing: bothNothing), const Just('bothNothing'));
+    });
+  });
 }
+

--- a/test/types/no_params_test.dart
+++ b/test/types/no_params_test.dart
@@ -1,0 +1,19 @@
+import 'package:convenience_types/types/no_params.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('NoParams', () {
+    test('It should be equal to another NoParams', () {
+      expect(const NoParams(), const NoParams());
+      expect(const NoParams() == const NoParams(), true);
+    });
+
+    test('It should have the same hashCode', () {
+      expect(const NoParams().hashCode, const NoParams().hashCode);
+    });
+
+    test('It should return a consistent toString', () {
+      expect(const NoParams().toString(), 'NoParams()');
+    });
+  });
+}

--- a/test/types/request_status_test.dart
+++ b/test/types/request_status_test.dart
@@ -308,4 +308,24 @@ void main() {
       );
     },
   );
+
+  group('State getters (isIdle, isLoading, etc)', () {
+    test('isIdle', () {
+      expect(const Idle().isIdle, true);
+      expect(const Loading().isIdle, false);
+    });
+    test('isLoading', () {
+      expect(const Loading().isLoading, true);
+      expect(const Idle().isLoading, false);
+    });
+    test('isSucceeded', () {
+      expect(const Succeeded(1).isSucceeded, true);
+      expect(const Idle().isSucceeded, false);
+    });
+    test('isFailed', () {
+      expect(const Failed(AppUnknownError()).isFailed, true);
+      expect(const Idle().isFailed, false);
+    });
+  });
 }
+

--- a/test/types/result_test.dart
+++ b/test/types/result_test.dart
@@ -140,4 +140,55 @@ void main() {
       );
     },
   );
+
+  group('isSuccess and isFailure', () {
+    test('isSuccess is true for Success and false for Failure', () {
+      expect(const Success(true).isSuccess, true);
+      expect(const Failure(AppUnknownError()).isSuccess, false);
+    });
+    test('isFailure is true for Failure and false for Success', () {
+      expect(const Failure(AppUnknownError()).isFailure, true);
+      expect(const Success(true).isFailure, false);
+    });
+  });
+
+  group('handle', () {
+    test('Calls onSuccess and returns its result when Success', () {
+      final res = const Success(42).handle(
+        onSuccess: (data) => data * 2,
+        onFailure: (_) => 0,
+      );
+      expect(res, 84);
+    });
+    test('Calls onFailure and returns its result when Failure', () {
+      final res = const Failure(AppUnknownError()).handle(
+        onSuccess: (data) => 1,
+        onFailure: (_) => 0,
+      );
+      expect(res, 0);
+    });
+  });
+
+  group('mapFailure', () {
+    test('Returns the same result when Success', () {
+      final res = const Success<String>('a').mapFailure((_) => const Success('b'));
+      expect(res, const Success('a'));
+    });
+    test('Applies combiner when Failure', () {
+      final res = const Failure<String>(AppUnknownError()).mapFailure((_) => const Success('b'));
+      expect(res, const Success('b'));
+    });
+  });
+
+  group('mapAsyncFailure', () {
+    test('Returns the same result when Success', () async {
+      final res = await const Success<String>('a').mapAsyncFailure((_) async => const Success('b'));
+      expect(res, const Success('a'));
+    });
+    test('Applies combiner when Failure', () async {
+      final res = await const Failure<String>(AppUnknownError()).mapAsyncFailure((_) async => const Success('b'));
+      expect(res, const Success('b'));
+    });
+  });
 }
+

--- a/test/types/sizing_information_test.dart
+++ b/test/types/sizing_information_test.dart
@@ -1,0 +1,56 @@
+import 'package:convenience_types/types/sizing_information.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ScreenType', () {
+    group('fromWidth', () {
+      test('It should return Small for width <= 670', () {
+        expect(ScreenType.fromWidth(0), ScreenType.Small);
+        expect(ScreenType.fromWidth(320), ScreenType.Small);
+        expect(ScreenType.fromWidth(670), ScreenType.Small);
+      });
+
+      test('It should return Medium for width > 670 and <= 1500', () {
+        expect(ScreenType.fromWidth(670.1), ScreenType.Medium);
+        expect(ScreenType.fromWidth(1024), ScreenType.Medium);
+        expect(ScreenType.fromWidth(1500), ScreenType.Medium);
+      });
+
+      test('It should return Large for width > 1500', () {
+        expect(ScreenType.fromWidth(1500.1), ScreenType.Large);
+        expect(ScreenType.fromWidth(1920), ScreenType.Large);
+        expect(ScreenType.fromWidth(3840), ScreenType.Large);
+      });
+    });
+  });
+
+  group('SizingInformation', () {
+    test('It should store screenType and screenSize', () {
+      const size = Size(800, 600);
+      const sizingInfo = SizingInformation(
+        screenType: ScreenType.Medium,
+        screenSize: size,
+      );
+
+      expect(sizingInfo.screenType, ScreenType.Medium);
+      expect(sizingInfo.screenSize, size);
+    });
+
+    test('It should be equatable via freezed', () {
+      const size = Size(800, 600);
+      const info1 = SizingInformation(
+        screenType: ScreenType.Medium,
+        screenSize: size,
+      );
+      const info2 = SizingInformation(
+        screenType: ScreenType.Medium,
+        screenSize: size,
+      );
+
+      expect(info1, info2);
+      expect(info1 == info2, true);
+      expect(info1.hashCode, info2.hashCode);
+    });
+  });
+}

--- a/test/types/unit_test.dart
+++ b/test/types/unit_test.dart
@@ -1,0 +1,34 @@
+import 'package:convenience_types/types/unit.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Unit', () {
+    test('It should be equal to another Unit', () {
+      expect(const Unit(), const Unit());
+      expect(const Unit() == const Unit(), true);
+    });
+
+    test('It should have the same hashCode', () {
+      expect(const Unit().hashCode, const Unit().hashCode);
+    });
+
+    test('It should return a consistent toString', () {
+      expect(const Unit().toString(), 'Unit()');
+    });
+  });
+
+  group('identity', () {
+    test('It should return the exact same integer value', () {
+      expect(identity(42), 42);
+    });
+
+    test('It should return the exact same string value', () {
+      expect(identity('test'), 'test');
+    });
+
+    test('It should return the exact same object reference', () {
+      final obj = Object();
+      expect(identical(identity(obj), obj), true);
+    });
+  });
+}

--- a/test/types/value_object_test.dart
+++ b/test/types/value_object_test.dart
@@ -1,0 +1,88 @@
+import 'package:convenience_types/errors/value_errors.dart';
+import 'package:convenience_types/types/result.dart';
+import 'package:convenience_types/types/unit.dart';
+import 'package:convenience_types/types/value_object.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _TestValidValueObject extends ValueObject<String> {
+  @override
+  final Result<String> value;
+
+  const _TestValidValueObject(this.value);
+}
+
+class _TestInvalidValueObject extends ValueObject<String> {
+  @override
+  final Result<String> value;
+
+  const _TestInvalidValueObject(this.value);
+}
+
+void main() {
+  group('ValueObject', () {
+    const validValue = _TestValidValueObject(Success('test'));
+    const invalidValue =
+        _TestInvalidValueObject(Failure(InvalidEmail(failedValue: 'bad')));
+
+    group('isValid', () {
+      test('It should return true when value is Success', () {
+        expect(validValue.isValid(), true);
+      });
+
+      test('It should return false when value is Failure', () {
+        expect(invalidValue.isValid(), false);
+      });
+    });
+
+    group('getOrCrash', () {
+      test('It should return the internal value when Success', () {
+        expect(validValue.getOrCrash(), 'test');
+      });
+
+      test('It should throw UnexpectedValueError when Failure', () {
+        expect(
+          () => invalidValue.getOrCrash(),
+          throwsA(isA<UnexpectedValueError<String>>()),
+        );
+      });
+    });
+
+    group('failureOrUnit', () {
+      test('It should return Success(Unit) when Success', () {
+        expect(validValue.failureOrUnit, const Success(Unit()));
+      });
+
+      test('It should return the same Failure when Failure', () {
+        expect(
+          invalidValue.failureOrUnit,
+          const Failure<Unit>(InvalidEmail(failedValue: 'bad')),
+        );
+      });
+    });
+
+    group('Equality and HashCode', () {
+      test('It should be equal to another instance with the same value', () {
+        const val1 = _TestValidValueObject(Success('test'));
+        const val2 = _TestValidValueObject(Success('test'));
+
+        expect(val1, val2);
+        expect(val1 == val2, true);
+        expect(val1.hashCode, val2.hashCode);
+      });
+
+      test('It should not be equal to an instance with a different value', () {
+        const val1 = _TestValidValueObject(Success('test'));
+        const val2 = _TestValidValueObject(Success('test2'));
+
+        expect(val1 == val2, false);
+        expect(val1.hashCode == val2.hashCode, false);
+      });
+    });
+
+    group('toString', () {
+      test('It should include the inner value inside Value()', () {
+        expect(validValue.toString(), 'Value(${const Success('test')})');
+      });
+    });
+  });
+}

--- a/test/util/form_util_test.dart
+++ b/test/util/form_util_test.dart
@@ -69,7 +69,7 @@ void main() {
         'It should return Failure(FormError(msg: errorMessage)), if the provided list of validators not passes',
         () {
           Result<String> validationTest = formUtils.validateField(
-            field: testField.field,
+            field: testFilledField.field,
             validators: testNotPassingValidators,
           );
 
@@ -85,7 +85,7 @@ void main() {
         'It should return Failure(FormError(msg: errorMessage)), with the first error message, if the provided list of validators not passes for more than one Validator',
         () {
           Result<String> validationTest = formUtils.validateField(
-            field: testField.field,
+            field: testFilledField.field,
             validators: testNotPassingValidators,
           );
 


### PR DESCRIPTION
# Pull Request: Test Suite Coverage & Documentation Improvements (v0.9.1)

## Description

This PR introduces comprehensive, 100% test coverage for the entire API surface of the `convenience_types` package. It focuses heavily on closing the testing gaps in the `errors/` domain, establishing coverage for omitted types, and expanding edgecase coverage in the existing test files.

Additionally, this PR fixes the `prefer_function_declarations_over_variables` lint rules inside the example app.

### Key Changes
*   **Mocktail Integration**: Added `mocktail` (`^1.0.4`) to `dev_dependencies` to correctly mock [DioException](cci:2://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/http_error_test.dart:8:0-8:62), [Response](cci:2://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/http_error_test.dart:12:0-12:60), and [RequestOptions](cci:2://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/http_error_test.dart:10:0-10:66) for HTTP parsing coverage without needing actual networking.
*   **Complete Coverage for `errors/` Module**:
    *   **AppErrors & Subclasses**: Covered the base [AppError](cci:2://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/app_error_test.dart:5:0-7:1) properties (custom equality checks, `hashCode`, [toString](cci:1://file:///Volumes/ssd/Developer/Dart/convenience_types/lib/errors/http_error.dart:34:2-35:109), `maybeResponse<T>()`), plus all 5 specific error subclasses (`ParseError`, `TokenNotFoundError`, etc.).
    *   **HTTP Errors**: Added coverage for all HTTP error variants (400, 401, 403, 404, 410, 422, 500) and specifically covered `msgDev` parsing for 400 and 422 errors. Tested [parseHttpError](cci:1://file:///Volumes/ssd/Developer/Dart/convenience_types/lib/errors/http_error.dart:171:0-311:1) logic including parsing `DioExceptionType.badResponse`, serialization overrides, custom `handleErrorMessage` callbacks, and fallbacks.
    *   **Specialty Errors**: Covered [cache_error_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/cache_error_test.dart:0:0-0:0), [storage_error_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/storage_error_test.dart:0:0-0:0), [device_info_error_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/device_info_error_test.dart:0:0-0:0), [value_errors_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/value_errors_test.dart:0:0-0:0) (including all explicit UI validation errors), [exceptions_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/exceptions_test.dart:0:0-0:0) (ParseException, CacheException), and [form_error_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/form_error_test.dart:0:0-0:0).
    *   **Default Error Messages**: Tested default constants in [default_error_messages_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/errors/default_error_messages_test.dart:0:0-0:0).
*   **Expanded Types Coverage (`types/`)**:
    *   **Unit & NoParams Test**: Added [unit_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/types/unit_test.dart:0:0-0:0) and [no_params_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/types/no_params_test.dart:0:0-0:0) confirming identity and standard equivalence (`==`, `hashCode`).
    *   **Sizing Information**: Tested `ScreenType.fromWidth()` responsive breakpoint calculations.
    *   **Value Objects**: Created test cases with valid and invalid concrete subclasses testing `isValid()`, `getOrCrash()`, `failureOrUnit`, and equivalence mappings based on the inner `Result` values.
    *   Added **missing getters/methods** into existing tests: `isSuccess`/`isFailure` getters and async mappings (`mapAsyncFailure`) in [result_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/types/result_test.dart:0:0-0:0); `isNothing`/`isJust` and `mapAsyncNothing` in [maybe_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/types/maybe_test.dart:0:0-0:0); state getters for [request_status_test.dart](cci:7://file:///Volumes/ssd/Developer/Dart/convenience_types/test/types/request_status_test.dart:0:0-0:0).
*   **Test Suite Adjustments**:
    *   Corrected generic typing mismatches across `Nothing<Never>` vs `Nothing<String>` assertions to support native equivalence.
    *   Fixed a bug in `form_utils_test.dart` where the [validateField](cci:1://file:///Volumes/ssd/Developer/Dart/convenience_types/lib/util/form_utils.dart:18:2-42:3) validation loop was erroneously testing empty fields against active validators.

## Validation Results

*   **Total tests run**: 161 tests executing across `types/`, `errors/`, and `util/` modules.
*   **Failures**: 0. 

The `convenience_types` package is now completely covered and protected against regressions!
